### PR TITLE
Create duty calendar web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/data/*.db
+/data/*.sqlite

--- a/api.php
+++ b/api.php
@@ -1,0 +1,458 @@
+<?php
+require __DIR__ . '/db.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$action = $_POST['action'] ?? null;
+
+if ($action === null) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Неизвестное действие'], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+try {
+    $db = get_db();
+
+    switch ($action) {
+        case 'get_calendar':
+            handleGetCalendar($db);
+            break;
+        case 'add_participant':
+            handleAddParticipant($db);
+            break;
+        case 'delete_participant':
+            handleDeleteParticipant($db);
+            break;
+        case 'reorder_participants':
+            handleReorderParticipants($db);
+            break;
+        case 'save_event':
+            handleSaveEvent($db);
+            break;
+        case 'delete_event':
+            handleDeleteEvent($db);
+            break;
+        case 'auto_assign':
+            handleAutoAssign($db);
+            break;
+        case 'get_statistics':
+            handleGetStatistics($db);
+            break;
+        default:
+            http_response_code(400);
+            echo json_encode(['error' => 'Неизвестное действие'], JSON_UNESCAPED_UNICODE);
+            break;
+    }
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode([
+        'error' => 'Произошла ошибка',
+        'details' => $e->getMessage(),
+    ], JSON_UNESCAPED_UNICODE);
+}
+
+function handleGetCalendar(PDO $db): void
+{
+    $month = max(1, min(12, (int) ($_POST['month'] ?? date('n'))));
+    $year = (int) ($_POST['year'] ?? date('Y'));
+
+    $participants = fetchParticipants($db);
+    [$startDate, $endDate] = monthBounds($year, $month);
+
+    $stmt = $db->prepare('SELECT * FROM events WHERE NOT (date(end_date) < :start OR date(start_date) > :end)');
+    $stmt->execute([
+        ':start' => $startDate,
+        ':end' => $endDate,
+    ]);
+    $events = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    echo json_encode([
+        'participants' => $participants,
+        'events' => $events,
+        'month' => $month,
+        'year' => $year,
+    ], JSON_UNESCAPED_UNICODE);
+}
+
+function handleAddParticipant(PDO $db): void
+{
+    $name = trim((string) ($_POST['name'] ?? ''));
+    if ($name === '') {
+        http_response_code(422);
+        echo json_encode(['error' => 'Имя не может быть пустым'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $maxSort = (int) $db->query('SELECT COALESCE(MAX(sort_order), 0) FROM participants')->fetchColumn();
+    $stmt = $db->prepare('INSERT INTO participants (name, sort_order) VALUES (:name, :sort)');
+    $stmt->execute([
+        ':name' => $name,
+        ':sort' => $maxSort + 1,
+    ]);
+
+    echo json_encode(['participant' => ['id' => $db->lastInsertId(), 'name' => $name]], JSON_UNESCAPED_UNICODE);
+}
+
+function handleDeleteParticipant(PDO $db): void
+{
+    $id = (int) ($_POST['id'] ?? 0);
+    if ($id <= 0) {
+        http_response_code(422);
+        echo json_encode(['error' => 'Некорректный идентификатор'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $stmt = $db->prepare('DELETE FROM participants WHERE id = :id');
+    $stmt->execute([':id' => $id]);
+
+    echo json_encode(['success' => true], JSON_UNESCAPED_UNICODE);
+}
+
+function handleReorderParticipants(PDO $db): void
+{
+    $order = $_POST['order'] ?? [];
+    if (!is_array($order)) {
+        http_response_code(422);
+        echo json_encode(['error' => 'Некорректный формат'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $stmt = $db->prepare('UPDATE participants SET sort_order = :sort WHERE id = :id');
+    foreach ($order as $index => $id) {
+        $stmt->execute([
+            ':sort' => $index,
+            ':id' => (int) $id,
+        ]);
+    }
+
+    echo json_encode(['success' => true], JSON_UNESCAPED_UNICODE);
+}
+
+function handleSaveEvent(PDO $db): void
+{
+    $participantId = (int) ($_POST['participant_id'] ?? 0);
+    $type = trim((string) ($_POST['type'] ?? ''));
+    $start = (string) ($_POST['start_date'] ?? '');
+    $end = (string) ($_POST['end_date'] ?? '');
+
+    if ($participantId <= 0 || $type === '' || $start === '') {
+        http_response_code(422);
+        echo json_encode(['error' => 'Недостаточно данных'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    if ($end === '') {
+        $end = $start;
+    }
+
+    if (!validateDate($start) || !validateDate($end) || $end < $start) {
+        http_response_code(422);
+        echo json_encode(['error' => 'Некорректные даты'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $allowed = ['duty', 'important', 'vacation', 'trip', 'sick'];
+    if (!in_array($type, $allowed, true)) {
+        http_response_code(422);
+        echo json_encode(['error' => 'Неизвестный тип события'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $stmt = $db->prepare(
+        'SELECT COUNT(*) FROM events WHERE participant_id = :pid AND NOT (date(end_date) < :start OR date(start_date) > :end)'
+    );
+    $stmt->execute([
+        ':pid' => $participantId,
+        ':start' => $start,
+        ':end' => $end,
+    ]);
+    $overlaps = (int) $stmt->fetchColumn();
+    if ($overlaps > 0) {
+        http_response_code(409);
+        echo json_encode(['error' => 'Событие пересекается с существующим'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $stmt = $db->prepare('INSERT INTO events (participant_id, type, start_date, end_date) VALUES (:pid, :type, :start, :end)');
+    $stmt->execute([
+        ':pid' => $participantId,
+        ':type' => $type,
+        ':start' => $start,
+        ':end' => $end,
+    ]);
+
+    $eventId = (int) $db->lastInsertId();
+    $stmt = $db->prepare('SELECT * FROM events WHERE id = :id');
+    $stmt->execute([':id' => $eventId]);
+    $event = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    echo json_encode(['event' => $event], JSON_UNESCAPED_UNICODE);
+}
+
+function handleDeleteEvent(PDO $db): void
+{
+    $eventId = (int) ($_POST['id'] ?? 0);
+    if ($eventId <= 0) {
+        http_response_code(422);
+        echo json_encode(['error' => 'Некорректный идентификатор'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $stmt = $db->prepare('DELETE FROM events WHERE id = :id');
+    $stmt->execute([':id' => $eventId]);
+
+    echo json_encode(['success' => true], JSON_UNESCAPED_UNICODE);
+}
+
+function handleAutoAssign(PDO $db): void
+{
+    $month = max(1, min(12, (int) ($_POST['month'] ?? date('n'))));
+    $year = (int) ($_POST['year'] ?? date('Y'));
+    $force = filter_var($_POST['force'] ?? false, FILTER_VALIDATE_BOOLEAN);
+
+    [$startDate, $endDate] = monthBounds($year, $month);
+
+    $stmt = $db->prepare("SELECT COUNT(*) FROM events WHERE type = 'duty' AND date(start_date) BETWEEN :start AND :end");
+    $stmt->execute([':start' => $startDate, ':end' => $endDate]);
+    $existingCount = (int) $stmt->fetchColumn();
+
+    if ($existingCount > 0 && !$force) {
+        echo json_encode(['needs_confirm' => true], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    if ($existingCount > 0) {
+        $del = $db->prepare("DELETE FROM events WHERE type = 'duty' AND date(start_date) BETWEEN :start AND :end");
+        $del->execute([':start' => $startDate, ':end' => $endDate]);
+    }
+
+    $participants = fetchParticipants($db);
+    if (empty($participants)) {
+        echo json_encode(['message' => 'Нет участников для распределения'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $countsStmt = $db->prepare(
+        "SELECT participant_id, strftime('%w', start_date) AS weekday, COUNT(*) AS cnt
+         FROM events
+         WHERE type = 'duty' AND strftime('%Y', start_date) = :year
+         GROUP BY participant_id, weekday"
+    );
+    $countsStmt->execute([':year' => sprintf('%04d', $year)]);
+    $weekdayCounts = [];
+    foreach ($participants as $participant) {
+        $weekdayCounts[$participant['id']] = array_fill(0, 7, 0);
+    }
+    while ($row = $countsStmt->fetch(PDO::FETCH_ASSOC)) {
+        $pid = (int) $row['participant_id'];
+        $weekdayCounts[$pid][(int) $row['weekday']] = (int) $row['cnt'];
+    }
+
+    $totalCounts = [];
+    foreach ($weekdayCounts as $pid => $counts) {
+        $totalCounts[$pid] = array_sum($counts);
+    }
+
+    $eventsStmt = $db->prepare(
+        'SELECT * FROM events WHERE type <> :duty AND NOT (date(end_date) < :start OR date(start_date) > :end)'
+    );
+    $eventsStmt->execute([
+        ':duty' => 'duty',
+        ':start' => $startDate,
+        ':end' => $endDate,
+    ]);
+    $blocking = [];
+    while ($event = $eventsStmt->fetch(PDO::FETCH_ASSOC)) {
+        $pid = (int) $event['participant_id'];
+        if (!isset($blocking[$pid])) {
+            $blocking[$pid] = [];
+        }
+        $start = new DateTime($event['start_date']);
+        $end = new DateTime($event['end_date']);
+        for ($cursor = clone $start; $cursor <= $end; $cursor->modify('+1 day')) {
+            $dateKey = $cursor->format('Y-m-d');
+            if ($dateKey < $startDate || $dateKey > $endDate) {
+                continue;
+            }
+            $blocking[$pid][$dateKey] = $event['type'];
+        }
+    }
+
+    $daysInMonth = (int) (new DateTimeImmutable($startDate))->format('t');
+    $insertStmt = $db->prepare('INSERT INTO events (participant_id, type, start_date, end_date) VALUES (:pid, :type, :start, :end)');
+    $createdEvents = [];
+    $skippedDays = [];
+
+    for ($day = 1; $day <= $daysInMonth; $day++) {
+        $dateObj = DateTimeImmutable::createFromFormat('Y-m-d', sprintf('%04d-%02d-%02d', $year, $month, $day));
+        if ($dateObj === false) {
+            continue;
+        }
+        $dateKey = $dateObj->format('Y-m-d');
+        $weekday = (int) $dateObj->format('w');
+
+        $available = [];
+        foreach ($participants as $participant) {
+            $pid = (int) $participant['id'];
+            if (isset($blocking[$pid][$dateKey])) {
+                continue;
+            }
+            $available[] = $pid;
+        }
+
+        if (empty($available)) {
+            $skippedDays[] = $dateKey;
+            continue;
+        }
+
+        usort($available, function ($a, $b) use ($weekdayCounts, $weekday, $totalCounts) {
+            $weekdayDiff = $weekdayCounts[$a][$weekday] <=> $weekdayCounts[$b][$weekday];
+            if ($weekdayDiff !== 0) {
+                return $weekdayDiff;
+            }
+            $totalDiff = $totalCounts[$a] <=> $totalCounts[$b];
+            if ($totalDiff !== 0) {
+                return $totalDiff;
+            }
+            return mt_rand(-1, 1);
+        });
+
+        $selected = $available[0];
+        $insertStmt->execute([
+            ':pid' => $selected,
+            ':type' => 'duty',
+            ':start' => $dateKey,
+            ':end' => $dateKey,
+        ]);
+        $eventId = (int) $db->lastInsertId();
+        $createdEvents[] = [
+            'id' => $eventId,
+            'participant_id' => $selected,
+            'type' => 'duty',
+            'start_date' => $dateKey,
+            'end_date' => $dateKey,
+        ];
+        $weekdayCounts[$selected][$weekday]++;
+        $totalCounts[$selected]++;
+    }
+
+    $response = ['events' => $createdEvents];
+    if (!empty($skippedDays)) {
+        $response['skipped'] = $skippedDays;
+    }
+
+    echo json_encode($response, JSON_UNESCAPED_UNICODE);
+}
+
+function handleGetStatistics(PDO $db): void
+{
+    $year = (int) ($_POST['year'] ?? date('Y'));
+    $yearString = sprintf('%04d', $year);
+    $participants = fetchParticipants($db);
+
+    $weekdayData = [];
+    foreach ($participants as $participant) {
+        $weekdayData[$participant['id']] = array_fill(0, 7, 0);
+    }
+
+    $stmt = $db->prepare(
+        "SELECT participant_id, strftime('%w', start_date) AS weekday, COUNT(*) AS cnt
+         FROM events
+         WHERE type = 'duty' AND strftime('%Y', start_date) = :year
+         GROUP BY participant_id, weekday"
+    );
+    $stmt->execute([':year' => $yearString]);
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $pid = (int) $row['participant_id'];
+        if (!isset($weekdayData[$pid])) {
+            $weekdayData[$pid] = array_fill(0, 7, 0);
+        }
+        $weekdayData[$pid][(int) $row['weekday']] = (int) $row['cnt'];
+    }
+
+    $rangeStart = sprintf('%04d-01-01', $year);
+    $rangeEnd = sprintf('%04d-12-31', $year);
+    $stmt = $db->prepare(
+        "SELECT participant_id, type, start_date, end_date
+         FROM events
+         WHERE type IN ('vacation', 'sick')
+         AND NOT (date(end_date) < :start OR date(start_date) > :end)"
+    );
+    $stmt->execute([':start' => $rangeStart, ':end' => $rangeEnd]);
+
+    $extraData = [];
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $pid = (int) $row['participant_id'];
+        if (!isset($extraData[$pid])) {
+            $extraData[$pid] = ['vacation' => 0, 'sick' => 0];
+        }
+        $type = $row['type'];
+        $start = new DateTime(max($row['start_date'], $rangeStart));
+        $end = new DateTime(min($row['end_date'], $rangeEnd));
+        $days = (int) $end->diff($start)->format('%a') + 1;
+        if ($days < 0) {
+            $days = 0;
+        }
+        if ($type === 'vacation') {
+            $extraData[$pid]['vacation'] += $days;
+        } elseif ($type === 'sick') {
+            $extraData[$pid]['sick'] += $days;
+        }
+    }
+
+    $yearsStmt = $db->query("SELECT DISTINCT strftime('%Y', start_date) AS y FROM events ORDER BY y DESC");
+    $years = [];
+    while ($row = $yearsStmt->fetch(PDO::FETCH_ASSOC)) {
+        if ($row['y'] !== null) {
+            $years[] = (int) $row['y'];
+        }
+    }
+    if (!in_array($year, $years, true)) {
+        $years[] = $year;
+    }
+    rsort($years);
+
+    $result = [];
+    foreach ($participants as $participant) {
+        $pid = (int) $participant['id'];
+        $weekdays = $weekdayData[$pid] ?? array_fill(0, 7, 0);
+        $total = array_sum($weekdays);
+        $vacation = $extraData[$pid]['vacation'] ?? 0;
+        $sick = $extraData[$pid]['sick'] ?? 0;
+        $result[] = [
+            'id' => $pid,
+            'name' => $participant['name'],
+            'weekdays' => $weekdays,
+            'total' => $total,
+            'vacation' => $vacation,
+            'sick' => $sick,
+        ];
+    }
+
+    echo json_encode([
+        'year' => $year,
+        'years' => array_values(array_unique($years)),
+        'data' => $result,
+    ], JSON_UNESCAPED_UNICODE);
+}
+
+function fetchParticipants(PDO $db): array
+{
+    $stmt = $db->query('SELECT id, name FROM participants ORDER BY sort_order, id');
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function monthBounds(int $year, int $month): array
+{
+    $start = sprintf('%04d-%02d-01', $year, $month);
+    $days = cal_days_in_month(CAL_GREGORIAN, $month, $year);
+    $end = sprintf('%04d-%02d-%02d', $year, $month, $days);
+    return [$start, $end];
+}
+
+function validateDate(string $value): bool
+{
+    $date = DateTime::createFromFormat('Y-m-d', $value);
+    return $date && $date->format('Y-m-d') === $value;
+}

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,0 +1,642 @@
+(function () {
+    const page = document.body.dataset.page;
+    if (page === 'home') {
+        initCalendarPage();
+    } else if (page === 'stats') {
+        initStatsPage();
+    }
+
+    function initCalendarPage() {
+        const state = {
+            month: new Date().getMonth() + 1,
+            year: new Date().getFullYear(),
+            editing: false,
+            participants: [],
+            events: [],
+            pendingRange: null,
+        };
+
+        const calendarContainer = document.getElementById('calendar-container');
+        const currentMonthEl = document.getElementById('current-month');
+        const prevMonthBtn = document.getElementById('prev-month');
+        const nextMonthBtn = document.getElementById('next-month');
+        const editToggle = document.getElementById('edit-toggle');
+        const addParticipantBtn = document.getElementById('add-participant');
+        const infoMessage = document.getElementById('info-message');
+        const distributeBtn = document.getElementById('distribute');
+        const eventMenu = document.getElementById('event-menu');
+        const modal = createModal();
+
+        const eventLabels = {
+            duty: 'Х',
+            important: 'o',
+            vacation: 'Отпуск',
+            trip: 'Командировка',
+            sick: 'Больничный',
+        };
+
+        const rangeTypes = ['vacation', 'trip', 'sick'];
+
+        loadCalendar();
+
+        prevMonthBtn.addEventListener('click', () => {
+            changeMonth(-1);
+        });
+        nextMonthBtn.addEventListener('click', () => {
+            changeMonth(1);
+        });
+        editToggle.addEventListener('change', (event) => {
+            state.editing = event.target.checked;
+            if (!state.editing) {
+                clearPendingRange();
+                hideEventMenu();
+                infoMessage.textContent = '';
+            }
+            renderCalendar();
+        });
+        addParticipantBtn.addEventListener('click', () => {
+            if (!state.editing) return;
+            const name = prompt('Введите фамилию участника');
+            if (name) {
+                addParticipant(name.trim());
+            }
+        });
+        distributeBtn.addEventListener('click', handleAutoAssign);
+
+        document.addEventListener('click', (event) => {
+            if (eventMenu.classList.contains('hidden')) {
+                return;
+            }
+            if (!eventMenu.contains(event.target)) {
+                hideEventMenu();
+            }
+        });
+
+        Array.from(eventMenu.querySelectorAll('button')).forEach((button) => {
+            button.addEventListener('click', () => {
+                const type = button.dataset.type;
+                const { participantId, date } = eventMenu.dataset;
+                hideEventMenu();
+                handleEventCreation(type, participantId, date);
+            });
+        });
+
+        function changeMonth(delta) {
+            state.month += delta;
+            if (state.month < 1) {
+                state.month = 12;
+                state.year -= 1;
+            } else if (state.month > 12) {
+                state.month = 1;
+                state.year += 1;
+            }
+            clearPendingRange();
+            infoMessage.textContent = '';
+            loadCalendar();
+        }
+
+        function loadCalendar() {
+            const formData = new FormData();
+            formData.append('action', 'get_calendar');
+            formData.append('month', String(state.month));
+            formData.append('year', String(state.year));
+
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            })
+                .then((response) => response.json())
+                .then((data) => {
+                    state.participants = data.participants || [];
+                    state.events = data.events || [];
+                    renderCalendar();
+                })
+                .catch(() => {
+                    infoMessage.textContent = 'Не удалось загрузить данные.';
+                });
+        }
+
+        function renderCalendar() {
+            const date = new Date(state.year, state.month - 1, 1);
+            currentMonthEl.textContent = date.toLocaleString('ru-RU', {
+                month: 'long',
+                year: 'numeric',
+            });
+
+            calendarContainer.innerHTML = '';
+            const table = document.createElement('table');
+            table.className = 'calendar-table';
+
+            const thead = document.createElement('thead');
+            const headerRow = document.createElement('tr');
+            const nameHeader = document.createElement('th');
+            nameHeader.textContent = 'ФИО';
+            headerRow.appendChild(nameHeader);
+
+            const daysInMonth = new Date(state.year, state.month, 0).getDate();
+            for (let day = 1; day <= daysInMonth; day++) {
+                const th = document.createElement('th');
+                th.textContent = day;
+                const dateKey = formatDate(state.year, state.month, day);
+                if (isWeekend(dateKey)) {
+                    th.classList.add('weekend');
+                }
+                headerRow.appendChild(th);
+            }
+            thead.appendChild(headerRow);
+            table.appendChild(thead);
+
+            const tbody = document.createElement('tbody');
+            const eventMap = buildEventMap();
+
+            state.participants.forEach((participant, index) => {
+                const row = document.createElement('tr');
+                const nameCell = document.createElement('td');
+                nameCell.textContent = participant.name;
+                if (state.editing) {
+                    const actions = document.createElement('div');
+                    actions.className = 'participant-actions';
+
+                    const upBtn = document.createElement('button');
+                    upBtn.textContent = '▲';
+                    upBtn.title = 'Выше';
+                    upBtn.addEventListener('click', () => moveParticipant(index, -1));
+
+                    const downBtn = document.createElement('button');
+                    downBtn.textContent = '▼';
+                    downBtn.title = 'Ниже';
+                    downBtn.addEventListener('click', () => moveParticipant(index, 1));
+
+                    const removeBtn = document.createElement('button');
+                    removeBtn.textContent = '✖';
+                    removeBtn.title = 'Удалить';
+                    removeBtn.addEventListener('click', () => deleteParticipant(participant.id));
+
+                    if (index === 0) {
+                        upBtn.disabled = true;
+                    }
+                    if (index === state.participants.length - 1) {
+                        downBtn.disabled = true;
+                    }
+
+                    actions.append(upBtn, downBtn, removeBtn);
+                    nameCell.appendChild(actions);
+                }
+                row.appendChild(nameCell);
+
+                for (let day = 1; day <= daysInMonth; day++) {
+                    const cell = document.createElement('td');
+                    const dateKey = formatDate(state.year, state.month, day);
+                    cell.dataset.date = dateKey;
+                    cell.dataset.participantId = participant.id;
+
+                    if (isWeekend(dateKey)) {
+                        cell.classList.add('weekend');
+                    }
+
+                    const eventInfo = (eventMap[participant.id] || {})[dateKey];
+                    if (eventInfo) {
+                        const { event, isStart, isEnd } = eventInfo;
+                        cell.dataset.eventId = event.id;
+                        cell.classList.add('has-event');
+                        cell.classList.add('event-' + event.type);
+                        cell.title = eventLabels[event.type] || '';
+
+                        if (event.type === 'duty') {
+                            cell.textContent = eventLabels.duty;
+                        } else if (event.type === 'important') {
+                            cell.textContent = eventLabels.important;
+                        } else if (rangeTypes.includes(event.type)) {
+                            cell.classList.add('range-' + event.type);
+                            if (isStart) {
+                                cell.classList.add('range-start');
+                                cell.textContent = eventLabels[event.type];
+                            } else if (isEnd) {
+                                cell.classList.add('range-end');
+                            } else {
+                                cell.classList.add('range-middle');
+                            }
+                        }
+                    } else {
+                        cell.classList.add('editable');
+                    }
+
+                    cell.addEventListener('click', (event) => handleCellClick(event, cell));
+                    row.appendChild(cell);
+                }
+
+                tbody.appendChild(row);
+            });
+
+            table.appendChild(tbody);
+            calendarContainer.appendChild(table);
+        }
+
+        function buildEventMap() {
+            const map = {};
+            state.events.forEach((event) => {
+                if (!map[event.participant_id]) {
+                    map[event.participant_id] = {};
+                }
+                const start = new Date(event.start_date);
+                const end = new Date(event.end_date);
+                for (let date = new Date(start); date <= end; date.setDate(date.getDate() + 1)) {
+                    const year = date.getFullYear();
+                    const month = date.getMonth() + 1;
+                    if (year !== state.year || month !== state.month) {
+                        continue;
+                    }
+                    const day = date.getDate();
+                    const dateKey = formatDate(year, month, day);
+                    map[event.participant_id][dateKey] = {
+                        event,
+                        isStart: dateKey === event.start_date,
+                        isEnd: dateKey === event.end_date,
+                    };
+                }
+            });
+            return map;
+        }
+
+        function handleCellClick(event, cell) {
+            event.stopPropagation();
+            if (!state.editing) {
+                return;
+            }
+
+            const eventId = cell.dataset.eventId;
+            const participantId = cell.dataset.participantId;
+            const date = cell.dataset.date;
+
+            if (state.pendingRange) {
+                if (state.pendingRange.participantId !== participantId) {
+                    infoMessage.textContent = 'Выберите окончание в той же строке.';
+                    return;
+                }
+                if (date <= state.pendingRange.startDate) {
+                    infoMessage.textContent = 'Дата окончания должна быть позже.';
+                    return;
+                }
+                saveEvent(participantId, state.pendingRange.type, state.pendingRange.startDate, date);
+                clearPendingRange();
+                return;
+            }
+
+            if (eventId) {
+                modal
+                    .confirm('Удалить выбранное событие?')
+                    .then((confirmed) => {
+                        if (confirmed) {
+                            deleteEvent(eventId);
+                        }
+                    });
+                return;
+            }
+
+            showEventMenu(cell, participantId, date, event);
+        }
+
+        function showEventMenu(cell, participantId, date, originalEvent) {
+            const rect = cell.getBoundingClientRect();
+            eventMenu.style.top = `${rect.bottom + window.scrollY}px`;
+            eventMenu.style.left = `${rect.left + window.scrollX}px`;
+            eventMenu.dataset.participantId = participantId;
+            eventMenu.dataset.date = date;
+            eventMenu.classList.remove('hidden');
+        }
+
+        function hideEventMenu() {
+            eventMenu.classList.add('hidden');
+            delete eventMenu.dataset.participantId;
+            delete eventMenu.dataset.date;
+        }
+
+        function handleEventCreation(type, participantId, date) {
+            if (rangeTypes.includes(type)) {
+                state.pendingRange = {
+                    type,
+                    participantId,
+                    startDate: date,
+                };
+                const cell = findCell(participantId, date);
+                if (cell) {
+                    cell.classList.add('pending-selection');
+                }
+                infoMessage.textContent = 'Выберите день окончания события в той же строке.';
+                return;
+            }
+
+            saveEvent(participantId, type, date, date);
+        }
+
+        function findCell(participantId, date) {
+            return calendarContainer.querySelector(`td[data-participant-id="${participantId}"][data-date="${date}"]`);
+        }
+
+        function clearPendingRange() {
+            if (state.pendingRange) {
+                const cell = findCell(state.pendingRange.participantId, state.pendingRange.startDate);
+                if (cell) {
+                    cell.classList.remove('pending-selection');
+                }
+            }
+            state.pendingRange = null;
+        }
+
+        function addParticipant(name) {
+            const formData = new FormData();
+            formData.append('action', 'add_participant');
+            formData.append('name', name);
+
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            })
+                .then((response) => response.json())
+                .then(() => {
+                    loadCalendar();
+                })
+                .catch(() => {
+                    infoMessage.textContent = 'Не удалось добавить участника.';
+                });
+        }
+
+        function deleteParticipant(id) {
+            modal
+                .confirm('Удалить участника и все его события?')
+                .then((confirmed) => {
+                    if (!confirmed) return;
+                    const formData = new FormData();
+                    formData.append('action', 'delete_participant');
+                    formData.append('id', id);
+                    fetch('api.php', {
+                        method: 'POST',
+                        body: formData,
+                    })
+                        .then((response) => response.json())
+                        .then(() => {
+                            loadCalendar();
+                        })
+                        .catch(() => {
+                            infoMessage.textContent = 'Не удалось удалить участника.';
+                        });
+                });
+        }
+
+        function moveParticipant(index, delta) {
+            const newIndex = index + delta;
+            if (newIndex < 0 || newIndex >= state.participants.length) {
+                return;
+            }
+            const reordered = [...state.participants];
+            const [moved] = reordered.splice(index, 1);
+            reordered.splice(newIndex, 0, moved);
+            state.participants = reordered;
+            renderCalendar();
+            saveParticipantOrder();
+        }
+
+        function saveParticipantOrder() {
+            const formData = new FormData();
+            formData.append('action', 'reorder_participants');
+            state.participants.forEach((participant) => {
+                formData.append('order[]', participant.id);
+            });
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            }).catch(() => {
+                infoMessage.textContent = 'Не удалось сохранить порядок участников.';
+            });
+        }
+
+        function saveEvent(participantId, type, startDate, endDate) {
+            const formData = new FormData();
+            formData.append('action', 'save_event');
+            formData.append('participant_id', participantId);
+            formData.append('type', type);
+            formData.append('start_date', startDate);
+            formData.append('end_date', endDate);
+
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            })
+                .then((response) => {
+                    if (!response.ok) {
+                        return response.json().then((data) => {
+                            throw new Error(data.error || 'Ошибка сохранения события');
+                        });
+                    }
+                    return response.json();
+                })
+                .then(() => {
+                    infoMessage.textContent = '';
+                    loadCalendar();
+                })
+                .catch((error) => {
+                    infoMessage.textContent = error.message;
+                    clearPendingRange();
+                });
+        }
+
+        function deleteEvent(eventId) {
+            const formData = new FormData();
+            formData.append('action', 'delete_event');
+            formData.append('id', eventId);
+
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            })
+                .then(() => {
+                    loadCalendar();
+                })
+                .catch(() => {
+                    infoMessage.textContent = 'Не удалось удалить событие.';
+                });
+        }
+
+        function handleAutoAssign() {
+            const formData = new FormData();
+            formData.append('action', 'auto_assign');
+            formData.append('month', state.month);
+            formData.append('year', state.year);
+            formData.append('force', 'false');
+
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            })
+                .then((response) => response.json())
+                .then((data) => {
+                    if (data.needs_confirm) {
+                        modal.confirm('Перезаписать существующие дежурства?').then((confirmed) => {
+                            if (!confirmed) return;
+                            const confirmData = new FormData();
+                            confirmData.append('action', 'auto_assign');
+                            confirmData.append('month', state.month);
+                            confirmData.append('year', state.year);
+                            confirmData.append('force', 'true');
+                            fetch('api.php', {
+                                method: 'POST',
+                                body: confirmData,
+                            })
+                                .then((response) => response.json())
+                                .then(handleAutoAssignResult)
+                                .catch(() => {
+                                    infoMessage.textContent = 'Не удалось распределить дежурства.';
+                                });
+                        });
+                    } else {
+                        handleAutoAssignResult(data);
+                    }
+                })
+                .catch(() => {
+                    infoMessage.textContent = 'Не удалось распределить дежурства.';
+                });
+        }
+
+        function handleAutoAssignResult(data) {
+            if (data.skipped && data.skipped.length > 0) {
+                infoMessage.textContent = 'Не удалось назначить дежурство на дни: ' + data.skipped.join(', ');
+            } else {
+                infoMessage.textContent = 'Дежурства успешно распределены.';
+            }
+            loadCalendar();
+        }
+    }
+
+    function initStatsPage() {
+        const yearSelect = document.getElementById('stats-year');
+        const tbody = document.getElementById('stats-body');
+        const state = {
+            year: new Date().getFullYear(),
+        };
+
+        yearSelect.addEventListener('change', () => {
+            state.year = parseInt(yearSelect.value, 10);
+            loadStats();
+        });
+
+        loadStats();
+
+        function loadStats() {
+            const formData = new FormData();
+            formData.append('action', 'get_statistics');
+            formData.append('year', state.year);
+
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            })
+                .then((response) => response.json())
+                .then((data) => {
+                    renderStats(data);
+                })
+                .catch(() => {
+                    tbody.innerHTML = '<tr><td colspan="11">Не удалось загрузить статистику</td></tr>';
+                });
+        }
+
+        function renderStats(data) {
+            if (data.years) {
+                yearSelect.innerHTML = '';
+                data.years.forEach((year) => {
+                    const option = document.createElement('option');
+                    option.value = year;
+                    option.textContent = year;
+                    if (parseInt(year, 10) === parseInt(data.year, 10)) {
+                        option.selected = true;
+                    }
+                    yearSelect.appendChild(option);
+                });
+            }
+
+            const weekdayOrder = [1, 2, 3, 4, 5, 6, 0];
+            tbody.innerHTML = '';
+            (data.data || []).forEach((row) => {
+                const tr = document.createElement('tr');
+                const nameCell = document.createElement('td');
+                nameCell.textContent = row.name;
+                tr.appendChild(nameCell);
+
+                weekdayOrder.forEach((weekday) => {
+                    const td = document.createElement('td');
+                    td.textContent = row.weekdays ? row.weekdays[weekday] || 0 : 0;
+                    tr.appendChild(td);
+                });
+
+                const vacation = document.createElement('td');
+                vacation.textContent = row.vacation || 0;
+                tr.appendChild(vacation);
+
+                const sick = document.createElement('td');
+                sick.textContent = row.sick || 0;
+                tr.appendChild(sick);
+
+                const total = document.createElement('td');
+                total.textContent = row.total || 0;
+                tr.appendChild(total);
+
+                tbody.appendChild(tr);
+            });
+
+            if (!tbody.children.length) {
+                tbody.innerHTML = '<tr><td colspan="11">Нет данных</td></tr>';
+            }
+        }
+    }
+
+    function createModal() {
+        const modal = document.getElementById('confirm-modal');
+        const messageEl = document.getElementById('modal-message');
+        const confirmBtn = document.getElementById('modal-confirm');
+        const cancelBtn = document.getElementById('modal-cancel');
+
+        let resolver = null;
+
+        confirmBtn.addEventListener('click', () => {
+            hideModal(true);
+        });
+        cancelBtn.addEventListener('click', () => {
+            hideModal(false);
+        });
+
+        function showModal(message) {
+            messageEl.textContent = message;
+            modal.classList.remove('hidden');
+            return new Promise((resolve) => {
+                resolver = resolve;
+            });
+        }
+
+        function hideModal(result) {
+            modal.classList.add('hidden');
+            if (resolver) {
+                resolver(result);
+                resolver = null;
+            }
+        }
+
+        return {
+            confirm(message) {
+                return showModal(message);
+            },
+        };
+    }
+
+    function formatDate(year, month, day) {
+        return [
+            year.toString().padStart(4, '0'),
+            month.toString().padStart(2, '0'),
+            day.toString().padStart(2, '0'),
+        ].join('-');
+    }
+
+    function isWeekend(dateString) {
+        const date = new Date(dateString + 'T00:00:00');
+        const day = date.getDay();
+        return day === 0 || day === 6;
+    }
+})();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,322 @@
+:root {
+    --bg-color: #f9fafb;
+    --accent: #2563eb;
+    --accent-light: #dbeafe;
+    --text-color: #111827;
+    --border-color: #e5e7eb;
+    --weekend-bg: #d1fae5;
+    --range-vacation: #fff3b0;
+    --range-trip: #e9d5ff;
+    --range-sick: #bfdbfe;
+    --important-color: #ef4444;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: "Segoe UI", sans-serif;
+    background: var(--bg-color);
+    color: var(--text-color);
+    min-height: 100vh;
+}
+
+.site-header {
+    background: white;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.top-nav {
+    display: flex;
+    gap: 1rem;
+    padding: 1rem;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+.nav-link {
+    text-decoration: none;
+    color: var(--text-color);
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    transition: background 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link.active {
+    background: var(--accent-light);
+    color: var(--accent);
+}
+
+.page-content {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 1.5rem;
+}
+
+.calendar-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+}
+
+.month-switcher {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.control-button,
+.primary-button,
+.secondary-button {
+    border: 1px solid var(--border-color);
+    background: white;
+    padding: 0.4rem 0.75rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.95rem;
+    transition: background 0.2s ease, border 0.2s ease;
+}
+
+.primary-button {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: white;
+}
+
+.primary-button:hover {
+    background: #1d4ed8;
+}
+
+.secondary-button:hover,
+.control-button:hover {
+    background: var(--accent-light);
+    border-color: var(--accent);
+}
+
+.toggle-edit label {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-weight: 600;
+}
+
+.info-message {
+    min-height: 1.5rem;
+    margin-bottom: 0.75rem;
+    color: var(--accent);
+}
+
+.calendar-container {
+    overflow-x: auto;
+    background: white;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem;
+}
+
+.calendar-table {
+    border-collapse: collapse;
+    width: 100%;
+    min-width: 720px;
+}
+
+.calendar-table th,
+.calendar-table td {
+    border: 1px solid var(--border-color);
+    text-align: center;
+    padding: 0.5rem;
+    min-width: 2.75rem;
+    position: relative;
+}
+
+.calendar-table th:first-child,
+.calendar-table td:first-child {
+    position: sticky;
+    left: 0;
+    background: #f1f5f9;
+    z-index: 1;
+}
+
+.calendar-table th.weekend,
+.calendar-table td.weekend {
+    background: var(--weekend-bg);
+}
+
+.calendar-table td.has-event {
+    cursor: pointer;
+}
+
+.calendar-table td.editable {
+    cursor: pointer;
+}
+
+.calendar-table td.event-duty {
+    font-weight: 700;
+    color: var(--important-color);
+}
+
+.calendar-table td.event-important {
+    color: #111827;
+    font-weight: 600;
+}
+
+.calendar-table td.range-vacation,
+.calendar-table td.range-trip,
+.calendar-table td.range-sick {
+    color: #111827;
+}
+
+.calendar-table td.range-vacation {
+    background: var(--range-vacation);
+}
+
+.calendar-table td.range-trip {
+    background: var(--range-trip);
+}
+
+.calendar-table td.range-sick {
+    background: var(--range-sick);
+}
+
+.calendar-table td.range-start::after,
+.calendar-table td.range-middle::after,
+.calendar-table td.range-end::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border-radius: 0;
+}
+
+.calendar-table td.range-start {
+    border-top-left-radius: 12px;
+    border-bottom-left-radius: 12px;
+}
+
+.calendar-table td.range-end {
+    border-top-right-radius: 12px;
+    border-bottom-right-radius: 12px;
+}
+
+.participant-actions {
+    display: flex;
+    gap: 0.25rem;
+    justify-content: center;
+    margin-top: 0.35rem;
+}
+
+.participant-actions button {
+    font-size: 0.75rem;
+    padding: 0.2rem 0.35rem;
+}
+
+.event-menu {
+    position: absolute;
+    background: white;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.18);
+    display: flex;
+    flex-direction: column;
+    min-width: 160px;
+    z-index: 10;
+}
+
+.event-menu button {
+    background: none;
+    border: none;
+    padding: 0.6rem 1rem;
+    text-align: left;
+    cursor: pointer;
+}
+
+.event-menu button:hover {
+    background: var(--accent-light);
+}
+
+.hidden {
+    display: none !important;
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+}
+
+.modal .modal-content {
+    background: white;
+    padding: 1.5rem;
+    border-radius: 10px;
+    max-width: 360px;
+    width: calc(100% - 2rem);
+}
+
+.modal-message {
+    margin-bottom: 1rem;
+    font-size: 1rem;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+}
+
+.stats-section {
+    background: white;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem;
+}
+
+.stats-controls {
+    margin-bottom: 1rem;
+}
+
+.stats-select {
+    padding: 0.4rem 0.6rem;
+}
+
+.stats-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.stats-table th,
+.stats-table td {
+    border: 1px solid var(--border-color);
+    padding: 0.5rem;
+    text-align: center;
+}
+
+.stats-table tbody tr:nth-child(odd) {
+    background: #f8fafc;
+}
+
+.pending-selection {
+    outline: 2px dashed var(--accent);
+}
+
+@media (max-width: 768px) {
+    .calendar-controls {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .calendar-table {
+        min-width: 600px;
+    }
+}

--- a/db.php
+++ b/db.php
@@ -1,0 +1,67 @@
+<?php
+function get_db(): PDO
+{
+    static $pdo = null;
+    if ($pdo !== null) {
+        return $pdo;
+    }
+
+    $dataDir = __DIR__ . DIRECTORY_SEPARATOR . 'data';
+    if (!is_dir($dataDir)) {
+        mkdir($dataDir, 0777, true);
+    }
+    $dbPath = $dataDir . DIRECTORY_SEPARATOR . 'app.db';
+    $needInit = !file_exists($dbPath);
+
+    $pdo = new PDO('sqlite:' . $dbPath);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $pdo->exec('PRAGMA foreign_keys = ON');
+
+    initializeDatabase($pdo, $needInit);
+
+    return $pdo;
+}
+
+function initializeDatabase(PDO $pdo, bool $isNew): void
+{
+    $pdo->exec(
+        'CREATE TABLE IF NOT EXISTS participants (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            sort_order INTEGER NOT NULL DEFAULT 0
+        )'
+    );
+
+    $pdo->exec(
+        'CREATE TABLE IF NOT EXISTS events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            participant_id INTEGER NOT NULL,
+            type TEXT NOT NULL,
+            start_date TEXT NOT NULL,
+            end_date TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY(participant_id) REFERENCES participants(id) ON DELETE CASCADE
+        )'
+    );
+
+    if ($isNew) {
+        seedParticipants($pdo);
+    } else {
+        $count = (int) $pdo->query('SELECT COUNT(*) FROM participants')->fetchColumn();
+        if ($count === 0) {
+            seedParticipants($pdo);
+        }
+    }
+}
+
+function seedParticipants(PDO $pdo): void
+{
+    $defaults = ['Иванов', 'Петров', 'Сидоров'];
+    $stmt = $pdo->prepare('INSERT INTO participants (name, sort_order) VALUES (:name, :sort)');
+    foreach ($defaults as $index => $name) {
+        $stmt->execute([
+            ':name' => $name,
+            ':sort' => $index,
+        ]);
+    }
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,95 @@
+<?php
+require __DIR__ . '/db.php';
+
+$page = $_GET['page'] ?? 'home';
+$page = $page === 'stats' ? 'stats' : 'home';
+
+?><!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>График дежурств</title>
+    <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body data-page="<?php echo htmlspecialchars($page, ENT_QUOTES); ?>">
+    <header class="site-header">
+        <nav class="top-nav">
+            <a href="index.php" class="nav-link <?php echo $page === 'home' ? 'active' : ''; ?>">Главная</a>
+            <a href="index.php?page=stats" class="nav-link <?php echo $page === 'stats' ? 'active' : ''; ?>">Статистика</a>
+        </nav>
+    </header>
+
+    <main class="page-content">
+        <?php if ($page === 'home'): ?>
+            <section class="calendar-section">
+                <div class="calendar-controls">
+                    <div class="month-switcher">
+                        <button type="button" id="prev-month" class="control-button">◀</button>
+                        <div id="current-month" class="current-month"></div>
+                        <button type="button" id="next-month" class="control-button">▶</button>
+                    </div>
+                    <div class="toggle-edit">
+                        <label>
+                            <input type="checkbox" id="edit-toggle">
+                            Режим редактирования
+                        </label>
+                    </div>
+                    <div class="calendar-actions">
+                        <button type="button" id="distribute" class="primary-button">Распределить</button>
+                        <button type="button" id="add-participant" class="secondary-button">Добавить участника</button>
+                    </div>
+                </div>
+                <div id="info-message" class="info-message" role="status"></div>
+                <div id="calendar-container" class="calendar-container"></div>
+            </section>
+        <?php else: ?>
+            <section class="stats-section">
+                <div class="stats-controls">
+                    <label for="stats-year">Год:</label>
+                    <select id="stats-year" class="stats-select"></select>
+                </div>
+                <div class="stats-table-wrapper">
+                    <table class="stats-table">
+                        <thead>
+                            <tr>
+                                <th>ФИО</th>
+                                <th>Пн</th>
+                                <th>Вт</th>
+                                <th>Ср</th>
+                                <th>Чт</th>
+                                <th>Пт</th>
+                                <th>Сб</th>
+                                <th>Вс</th>
+                                <th>Отпуск</th>
+                                <th>Больничный</th>
+                                <th>Всего</th>
+                            </tr>
+                        </thead>
+                        <tbody id="stats-body"></tbody>
+                    </table>
+                </div>
+            </section>
+        <?php endif; ?>
+    </main>
+
+    <div id="event-menu" class="event-menu hidden">
+        <button type="button" data-type="duty">Дежурство</button>
+        <button type="button" data-type="important">Важный день</button>
+        <button type="button" data-type="vacation">Отпуск</button>
+        <button type="button" data-type="trip">Командировка</button>
+        <button type="button" data-type="sick">Больничный</button>
+    </div>
+
+    <div id="confirm-modal" class="modal hidden" role="dialog" aria-modal="true">
+        <div class="modal-content">
+            <div class="modal-message" id="modal-message"></div>
+            <div class="modal-actions">
+                <button type="button" id="modal-confirm" class="primary-button">Да</button>
+                <button type="button" id="modal-cancel" class="secondary-button">Нет</button>
+            </div>
+        </div>
+    </div>
+
+    <script src="assets/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add SQLite-backed data layer with participant seeding and event storage
- implement calendar UI with editing tools, multi-day events, and automatic duty distribution
- provide statistics view summarizing duties and leave days per participant

## Testing
- php -l db.php
- php -l api.php
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68d0fa3e4acc83229971fb43bac228ce