### PR TITLE
Add study event type and fix calendar hover artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/data/*.db
+/data/*.sqlite
+/App_Data/*.db
+/App_Data/*.sqlite

--- a/App_Data/.gitignore
+++ b/App_Data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/api.php
+++ b/api.php
@@ -1,0 +1,1405 @@
+<?php
+require __DIR__ . '/db.php';
+
+const DEFAULT_EDIT_PASSWORD = '12345';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$action = $_POST['action'] ?? null;
+
+if ($action === null) {
+    log_warning('Получен запрос без указания действия', [
+        'keys' => array_keys($_POST),
+        'ip' => $_SERVER['REMOTE_ADDR'] ?? null,
+    ]);
+    http_response_code(400);
+    echo json_encode(['error' => 'Неизвестное действие'], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+log_info('Начало обработки API-запроса', [
+    'action' => $action,
+    'ip' => $_SERVER['REMOTE_ADDR'] ?? null,
+]);
+
+try {
+    $db = get_db();
+
+    switch ($action) {
+        case 'get_calendar':
+            handleGetCalendar($db);
+            break;
+        case 'add_participant':
+            handleAddParticipant($db);
+            break;
+        case 'delete_participant':
+            handleDeleteParticipant($db);
+            break;
+        case 'reorder_participants':
+            handleReorderParticipants($db);
+            break;
+        case 'save_event':
+            handleSaveEvent($db);
+            break;
+        case 'delete_event':
+            handleDeleteEvent($db);
+            break;
+        case 'auto_assign':
+            handleAutoAssign($db);
+            break;
+        case 'clear_month_duties':
+            handleClearMonthDuties($db);
+            break;
+        case 'get_statistics':
+            handleGetStatistics($db);
+            break;
+        case 'generate_report':
+            handleGenerateReport($db);
+            break;
+        case 'set_month_approval':
+            handleSetMonthApproval($db);
+            break;
+        default:
+            log_warning('Запрошено неизвестное действие', [
+                'action' => $action,
+            ]);
+            http_response_code(400);
+            echo json_encode(['error' => 'Неизвестное действие'], JSON_UNESCAPED_UNICODE);
+            break;
+    }
+} catch (Throwable $e) {
+    log_error('Ошибка при обработке API-запроса', [
+        'action' => $action,
+        'error' => $e->getMessage(),
+    ]);
+    http_response_code(500);
+    echo json_encode([
+        'error' => 'Произошла ошибка',
+        'details' => $e->getMessage(),
+    ], JSON_UNESCAPED_UNICODE);
+}
+
+function handleGetCalendar(PDO $db): void
+{
+    $month = max(1, min(12, (int) ($_POST['month'] ?? date('n'))));
+    $year = (int) ($_POST['year'] ?? date('Y'));
+
+    log_info('Запрошен календарь', [
+        'month' => $month,
+        'year' => $year,
+    ]);
+
+    $participants = fetchParticipants($db);
+    [$startDate, $endDate] = monthBounds($year, $month);
+
+    $stmt = $db->prepare('SELECT * FROM events WHERE NOT (date(end_date) < :start OR date(start_date) > :end)');
+    $stmt->execute([
+        ':start' => $startDate,
+        ':end' => $endDate,
+    ]);
+    $events = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    echo json_encode([
+        'participants' => $participants,
+        'events' => $events,
+        'month' => $month,
+        'year' => $year,
+        'locked' => isMonthLocked($db, $year, $month),
+    ], JSON_UNESCAPED_UNICODE);
+}
+
+function handleAddParticipant(PDO $db): void
+{
+    $name = trim((string) ($_POST['name'] ?? ''));
+    if ($name === '') {
+        log_warning('Попытка добавить участника с пустым именем');
+        http_response_code(422);
+        echo json_encode(['error' => 'Имя не может быть пустым'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $maxSort = (int) $db->query('SELECT COALESCE(MAX(sort_order), 0) FROM participants')->fetchColumn();
+    $stmt = $db->prepare('INSERT INTO participants (name, sort_order) VALUES (:name, :sort)');
+    $stmt->execute([
+        ':name' => $name,
+        ':sort' => $maxSort + 1,
+    ]);
+
+    $id = (int) $db->lastInsertId();
+    log_info('Добавлен новый участник', [
+        'id' => $id,
+        'name' => $name,
+    ]);
+
+    echo json_encode(['participant' => ['id' => $id, 'name' => $name]], JSON_UNESCAPED_UNICODE);
+}
+
+function handleDeleteParticipant(PDO $db): void
+{
+    $id = (int) ($_POST['id'] ?? 0);
+    if ($id <= 0) {
+        log_warning('Попытка удалить участника с некорректным идентификатором', [
+            'id' => $id,
+        ]);
+        http_response_code(422);
+        echo json_encode(['error' => 'Некорректный идентификатор'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $stmt = $db->prepare('DELETE FROM participants WHERE id = :id');
+    $stmt->execute([':id' => $id]);
+
+    log_info('Удалён участник', [
+        'id' => $id,
+    ]);
+
+    echo json_encode(['success' => true], JSON_UNESCAPED_UNICODE);
+}
+
+function handleReorderParticipants(PDO $db): void
+{
+    $order = $_POST['order'] ?? [];
+    if (!is_array($order)) {
+        log_warning('Попытка изменить порядок участников с некорректными данными');
+        http_response_code(422);
+        echo json_encode(['error' => 'Некорректный формат'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $stmt = $db->prepare('UPDATE participants SET sort_order = :sort WHERE id = :id');
+    foreach ($order as $index => $id) {
+        $stmt->execute([
+            ':sort' => $index,
+            ':id' => (int) $id,
+        ]);
+    }
+
+    log_info('Обновлён порядок участников', [
+        'order' => array_values(array_map('intval', $order)),
+    ]);
+
+    echo json_encode(['success' => true], JSON_UNESCAPED_UNICODE);
+}
+
+function handleSaveEvent(PDO $db): void
+{
+    $participantId = (int) ($_POST['participant_id'] ?? 0);
+    $type = trim((string) ($_POST['type'] ?? ''));
+    $start = (string) ($_POST['start_date'] ?? '');
+    $end = (string) ($_POST['end_date'] ?? '');
+
+    if ($participantId <= 0 || $type === '' || $start === '') {
+        log_warning('Попытка сохранить событие с неполными данными', [
+            'participant_id' => $participantId,
+            'type' => $type,
+            'start' => $start,
+            'end' => $end,
+        ]);
+        http_response_code(422);
+        echo json_encode(['error' => 'Недостаточно данных'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    if ($end === '') {
+        $end = $start;
+    }
+
+    if (!validateDate($start) || !validateDate($end) || $end < $start) {
+        log_warning('Попытка сохранить событие с некорректными датами', [
+            'start' => $start,
+            'end' => $end,
+        ]);
+        http_response_code(422);
+        echo json_encode(['error' => 'Некорректные даты'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $lockedMonths = getLockedMonthsInRange($db, $start, $end);
+    if (!empty($lockedMonths)) {
+        log_warning('Попытка сохранить событие в утверждённом месяце', [
+            'participant_id' => $participantId,
+            'start' => $start,
+            'end' => $end,
+        ]);
+        respondLocked($lockedMonths);
+        return;
+    }
+
+    $allowed = ['duty', 'important', 'vacation', 'trip', 'sick', 'study'];
+    if (!in_array($type, $allowed, true)) {
+        log_warning('Попытка сохранить событие с неизвестным типом', [
+            'type' => $type,
+        ]);
+        http_response_code(422);
+        echo json_encode(['error' => 'Неизвестный тип события'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $stmt = $db->prepare(
+        'SELECT COUNT(*) FROM events WHERE participant_id = :pid AND NOT (date(end_date) < :start OR date(start_date) > :end)'
+    );
+    $stmt->execute([
+        ':pid' => $participantId,
+        ':start' => $start,
+        ':end' => $end,
+    ]);
+    $overlaps = (int) $stmt->fetchColumn();
+    if ($overlaps > 0) {
+        log_warning('Попытка сохранить пересекающееся событие', [
+            'participant_id' => $participantId,
+            'start' => $start,
+            'end' => $end,
+        ]);
+        http_response_code(409);
+        echo json_encode(['error' => 'Событие пересекается с существующим'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $stmt = $db->prepare('INSERT INTO events (participant_id, type, start_date, end_date) VALUES (:pid, :type, :start, :end)');
+    $stmt->execute([
+        ':pid' => $participantId,
+        ':type' => $type,
+        ':start' => $start,
+        ':end' => $end,
+    ]);
+
+    $eventId = (int) $db->lastInsertId();
+    $stmt = $db->prepare('SELECT * FROM events WHERE id = :id');
+    $stmt->execute([':id' => $eventId]);
+    $event = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    log_info('Сохранено событие', [
+        'event' => $event,
+    ]);
+
+    echo json_encode(['event' => $event], JSON_UNESCAPED_UNICODE);
+}
+
+function handleDeleteEvent(PDO $db): void
+{
+    $eventId = (int) ($_POST['id'] ?? 0);
+    if ($eventId <= 0) {
+        log_warning('Попытка удалить событие с некорректным идентификатором', [
+            'id' => $eventId,
+        ]);
+        http_response_code(422);
+        echo json_encode(['error' => 'Некорректный идентификатор'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $eventStmt = $db->prepare('SELECT start_date, end_date, participant_id, type FROM events WHERE id = :id');
+    $eventStmt->execute([':id' => $eventId]);
+    $event = $eventStmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($event) {
+        $lockedMonths = getLockedMonthsInRange($db, $event['start_date'], $event['end_date']);
+        if (!empty($lockedMonths)) {
+            log_warning('Попытка удалить событие из утверждённого месяца', [
+                'id' => $eventId,
+                'participant_id' => (int) $event['participant_id'],
+                'type' => $event['type'],
+            ]);
+            respondLocked($lockedMonths);
+            return;
+        }
+    }
+
+    $stmt = $db->prepare('DELETE FROM events WHERE id = :id');
+    $stmt->execute([':id' => $eventId]);
+
+    log_info('Удалено событие', [
+        'id' => $eventId,
+    ]);
+
+    echo json_encode(['success' => true], JSON_UNESCAPED_UNICODE);
+}
+
+function handleAutoAssign(PDO $db): void
+{
+    $month = max(1, min(12, (int) ($_POST['month'] ?? date('n'))));
+    $year = (int) ($_POST['year'] ?? date('Y'));
+    $force = filter_var($_POST['force'] ?? false, FILTER_VALIDATE_BOOLEAN);
+
+    log_info('Запрошено автоматическое распределение дежурств', [
+        'month' => $month,
+        'year' => $year,
+        'force' => $force,
+    ]);
+
+    if (isMonthLocked($db, $year, $month)) {
+        log_warning('Автораспределение недоступно для утверждённого месяца', [
+            'month' => $month,
+            'year' => $year,
+        ]);
+        respondLocked([[
+            'year' => $year,
+            'month' => $month,
+        ]]);
+        return;
+    }
+
+    if (!requireValidPassword($_POST['password'] ?? null, 'auto_assign')) {
+        return;
+    }
+
+    [$startDate, $endDate] = monthBounds($year, $month);
+
+    $stmt = $db->prepare("SELECT COUNT(*) FROM events WHERE type = 'duty' AND date(start_date) BETWEEN :start AND :end");
+    $stmt->execute([':start' => $startDate, ':end' => $endDate]);
+    $existingCount = (int) $stmt->fetchColumn();
+
+    if ($existingCount > 0 && !$force) {
+        log_info('Автораспределение дежурств требует подтверждения', [
+            'existing_duties' => $existingCount,
+        ]);
+        echo json_encode(['needs_confirm' => true], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    if ($existingCount > 0) {
+        $del = $db->prepare("DELETE FROM events WHERE type = 'duty' AND date(start_date) BETWEEN :start AND :end");
+        $del->execute([':start' => $startDate, ':end' => $endDate]);
+        log_info('Удалены существующие дежурства перед перераспределением', [
+            'count' => $existingCount,
+        ]);
+    }
+
+    $participants = fetchParticipants($db);
+    if (empty($participants)) {
+        log_warning('Автораспределение не выполнено — нет участников');
+        echo json_encode(['message' => 'Нет участников для распределения'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $countsStmt = $db->prepare(
+        "SELECT participant_id, strftime('%w', start_date) AS weekday, COUNT(*) AS cnt
+         FROM events
+         WHERE type = 'duty' AND strftime('%Y', start_date) = :year
+         GROUP BY participant_id, weekday"
+    );
+    $countsStmt->execute([':year' => sprintf('%04d', $year)]);
+    $weekdayCounts = [];
+    foreach ($participants as $participant) {
+        $weekdayCounts[$participant['id']] = array_fill(0, 7, 0);
+    }
+    while ($row = $countsStmt->fetch(PDO::FETCH_ASSOC)) {
+        $pid = (int) $row['participant_id'];
+        $weekdayCounts[$pid][(int) $row['weekday']] = (int) $row['cnt'];
+    }
+
+    $totalCounts = [];
+    foreach ($weekdayCounts as $pid => $counts) {
+        $totalCounts[$pid] = array_sum($counts);
+    }
+
+    $eventsStmt = $db->prepare(
+        'SELECT * FROM events WHERE type <> :duty AND NOT (date(end_date) < :start OR date(start_date) > :end)'
+    );
+    $eventsStmt->execute([
+        ':duty' => 'duty',
+        ':start' => $startDate,
+        ':end' => $endDate,
+    ]);
+    $blocking = [];
+    while ($event = $eventsStmt->fetch(PDO::FETCH_ASSOC)) {
+        $pid = (int) $event['participant_id'];
+        if (!isset($blocking[$pid])) {
+            $blocking[$pid] = [];
+        }
+        $start = new DateTime($event['start_date']);
+        $end = new DateTime($event['end_date']);
+        for ($cursor = clone $start; $cursor <= $end; $cursor->modify('+1 day')) {
+            $dateKey = $cursor->format('Y-m-d');
+            if ($dateKey < $startDate || $dateKey > $endDate) {
+                continue;
+            }
+            $blocking[$pid][$dateKey] = $event['type'];
+        }
+    }
+
+    $lastDutyStmt = $db->prepare(
+        "SELECT participant_id, start_date FROM events WHERE type = 'duty' AND date(start_date) < :start ORDER BY date(start_date) DESC LIMIT 1"
+    );
+    $lastDutyStmt->execute([':start' => $startDate]);
+    $lastAssignedParticipant = null;
+    $lastAssignedDate = null;
+    if ($prev = $lastDutyStmt->fetch(PDO::FETCH_ASSOC)) {
+        $lastAssignedParticipant = (int) $prev['participant_id'];
+        $lastAssignedDate = $prev['start_date'];
+    }
+
+    $daysInMonth = (int) (new DateTimeImmutable($startDate))->format('t');
+    $insertStmt = $db->prepare('INSERT INTO events (participant_id, type, start_date, end_date) VALUES (:pid, :type, :start, :end)');
+    $createdEvents = [];
+    $skippedDays = [];
+
+    for ($day = 1; $day <= $daysInMonth; $day++) {
+        $dateObj = DateTimeImmutable::createFromFormat('Y-m-d', sprintf('%04d-%02d-%02d', $year, $month, $day));
+        if ($dateObj === false) {
+            continue;
+        }
+        $dateKey = $dateObj->format('Y-m-d');
+        $weekday = (int) $dateObj->format('w');
+
+        $available = [];
+        foreach ($participants as $participant) {
+            $pid = (int) $participant['id'];
+            if (isset($blocking[$pid][$dateKey])) {
+                continue;
+            }
+            $available[] = $pid;
+        }
+
+        if (empty($available)) {
+            $skippedDays[] = $dateKey;
+            continue;
+        }
+
+        $candidates = $available;
+        if ($lastAssignedParticipant !== null && $lastAssignedDate !== null && areConsecutiveDates($lastAssignedDate, $dateKey)) {
+            $candidates = array_values(array_filter(
+                $candidates,
+                static fn($pid) => $pid !== $lastAssignedParticipant
+            ));
+        }
+
+        if (empty($candidates)) {
+            $skippedDays[] = $dateKey;
+            continue;
+        }
+
+        usort($candidates, function ($a, $b) use ($weekdayCounts, $weekday, $totalCounts) {
+            $weekdayDiff = $weekdayCounts[$a][$weekday] <=> $weekdayCounts[$b][$weekday];
+            if ($weekdayDiff !== 0) {
+                return $weekdayDiff;
+            }
+            $totalDiff = $totalCounts[$a] <=> $totalCounts[$b];
+            if ($totalDiff !== 0) {
+                return $totalDiff;
+            }
+            return mt_rand(-1, 1);
+        });
+
+        $selected = $candidates[0];
+        $insertStmt->execute([
+            ':pid' => $selected,
+            ':type' => 'duty',
+            ':start' => $dateKey,
+            ':end' => $dateKey,
+        ]);
+        $eventId = (int) $db->lastInsertId();
+        $createdEvents[] = [
+            'id' => $eventId,
+            'participant_id' => $selected,
+            'type' => 'duty',
+            'start_date' => $dateKey,
+            'end_date' => $dateKey,
+        ];
+        $weekdayCounts[$selected][$weekday]++;
+        $totalCounts[$selected]++;
+        $lastAssignedParticipant = $selected;
+        $lastAssignedDate = $dateKey;
+    }
+
+    $response = ['events' => $createdEvents];
+    if (!empty($skippedDays)) {
+        $response['skipped'] = $skippedDays;
+    }
+
+    log_info('Автораспределение завершено', [
+        'created' => count($createdEvents),
+        'skipped' => $skippedDays,
+    ]);
+
+    echo json_encode($response, JSON_UNESCAPED_UNICODE);
+}
+
+function handleClearMonthDuties(PDO $db): void
+{
+    $month = max(1, min(12, (int) ($_POST['month'] ?? date('n'))));
+    $year = (int) ($_POST['year'] ?? date('Y'));
+    [$startDate, $endDate] = monthBounds($year, $month);
+
+    log_info('Запрошено удаление дежурств за месяц', [
+        'month' => $month,
+        'year' => $year,
+    ]);
+
+    if (isMonthLocked($db, $year, $month)) {
+        log_warning('Удаление дежурств недоступно для утверждённого месяца', [
+            'month' => $month,
+            'year' => $year,
+        ]);
+        respondLocked([[
+            'year' => $year,
+            'month' => $month,
+        ]]);
+        return;
+    }
+
+    if (!requireValidPassword($_POST['password'] ?? null, 'clear_month_duties')) {
+        return;
+    }
+
+    $countStmt = $db->prepare(
+        "SELECT COUNT(*) FROM events WHERE type = 'duty' AND date(start_date) BETWEEN :start AND :end"
+    );
+    $countStmt->execute([
+        ':start' => $startDate,
+        ':end' => $endDate,
+    ]);
+    $existing = (int) $countStmt->fetchColumn();
+
+    if ($existing === 0) {
+        log_info('Дежурства для удаления не найдены', [
+            'month' => $month,
+            'year' => $year,
+        ]);
+        echo json_encode(['cleared' => 0], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $deleteStmt = $db->prepare(
+        "DELETE FROM events WHERE type = 'duty' AND date(start_date) BETWEEN :start AND :end"
+    );
+    $deleteStmt->execute([
+        ':start' => $startDate,
+        ':end' => $endDate,
+    ]);
+
+    log_info('Удалены дежурства за месяц', [
+        'month' => $month,
+        'year' => $year,
+        'removed' => $existing,
+    ]);
+
+    echo json_encode(['cleared' => $existing], JSON_UNESCAPED_UNICODE);
+}
+
+function handleSetMonthApproval(PDO $db): void
+{
+    $month = max(1, min(12, (int) ($_POST['month'] ?? date('n'))));
+    $year = (int) ($_POST['year'] ?? date('Y'));
+    $approved = filter_var($_POST['approved'] ?? false, FILTER_VALIDATE_BOOLEAN);
+
+    log_info('Изменение статуса утверждения месяца', [
+        'month' => $month,
+        'year' => $year,
+        'approved' => $approved,
+    ]);
+
+    if (!$approved && !requireValidPassword($_POST['password'] ?? null, 'set_month_approval')) {
+        return;
+    }
+
+    setMonthLocked($db, $year, $month, $approved);
+
+    if ($approved) {
+        log_info('Месяц утверждён', [
+            'month' => $month,
+            'year' => $year,
+        ]);
+    } else {
+        log_info('Утверждение месяца снято', [
+            'month' => $month,
+            'year' => $year,
+        ]);
+    }
+
+    echo json_encode(['locked' => isMonthLocked($db, $year, $month)], JSON_UNESCAPED_UNICODE);
+}
+
+function handleGetStatistics(PDO $db): void
+{
+    $year = (int) ($_POST['year'] ?? date('Y'));
+    $yearString = sprintf('%04d', $year);
+    $participants = fetchParticipants($db);
+
+    log_info('Запрошена статистика', [
+        'year' => $year,
+    ]);
+
+    $weekdayData = [];
+    foreach ($participants as $participant) {
+        $weekdayData[$participant['id']] = array_fill(0, 7, 0);
+    }
+
+    $stmt = $db->prepare(
+        "SELECT participant_id, strftime('%w', start_date) AS weekday, COUNT(*) AS cnt
+         FROM events
+         WHERE type = 'duty' AND strftime('%Y', start_date) = :year
+         GROUP BY participant_id, weekday"
+    );
+    $stmt->execute([':year' => $yearString]);
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $pid = (int) $row['participant_id'];
+        if (!isset($weekdayData[$pid])) {
+            $weekdayData[$pid] = array_fill(0, 7, 0);
+        }
+        $weekdayData[$pid][(int) $row['weekday']] = (int) $row['cnt'];
+    }
+
+    $rangeStart = sprintf('%04d-01-01', $year);
+    $rangeEnd = sprintf('%04d-12-31', $year);
+    $stmt = $db->prepare(
+        "SELECT participant_id, type, start_date, end_date
+         FROM events
+         WHERE type IN ('vacation', 'sick', 'trip', 'study')
+         AND NOT (date(end_date) < :start OR date(start_date) > :end)"
+    );
+    $stmt->execute([':start' => $rangeStart, ':end' => $rangeEnd]);
+
+    $extraData = [];
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $pid = (int) $row['participant_id'];
+        if (!isset($extraData[$pid])) {
+            $extraData[$pid] = [
+                'vacation' => 0,
+                'sick' => 0,
+                'trip' => 0,
+                'study' => 0,
+            ];
+        }
+        $type = $row['type'];
+        $start = new DateTime(max($row['start_date'], $rangeStart));
+        $end = new DateTime(min($row['end_date'], $rangeEnd));
+        $days = (int) $end->diff($start)->format('%a') + 1;
+        if ($days < 0) {
+            $days = 0;
+        }
+        if (isset($extraData[$pid][$type])) {
+            $extraData[$pid][$type] += $days;
+        }
+    }
+
+    $yearsStmt = $db->query("SELECT DISTINCT strftime('%Y', start_date) AS y FROM events ORDER BY y DESC");
+    $years = [];
+    while ($row = $yearsStmt->fetch(PDO::FETCH_ASSOC)) {
+        if ($row['y'] !== null) {
+            $years[] = (int) $row['y'];
+        }
+    }
+    if (!in_array($year, $years, true)) {
+        $years[] = $year;
+    }
+    rsort($years);
+
+    $result = [];
+    foreach ($participants as $participant) {
+        $pid = (int) $participant['id'];
+        $weekdays = $weekdayData[$pid] ?? array_fill(0, 7, 0);
+        $total = array_sum($weekdays);
+        $vacation = $extraData[$pid]['vacation'] ?? 0;
+        $sick = $extraData[$pid]['sick'] ?? 0;
+        $trip = $extraData[$pid]['trip'] ?? 0;
+        $study = $extraData[$pid]['study'] ?? 0;
+        $result[] = [
+            'id' => $pid,
+            'name' => $participant['name'],
+            'weekdays' => $weekdays,
+            'total' => $total,
+            'vacation' => $vacation,
+            'sick' => $sick,
+            'trip' => $trip,
+            'study' => $study,
+        ];
+    }
+
+    echo json_encode([
+        'year' => $year,
+        'years' => array_values(array_unique($years)),
+        'data' => $result,
+    ], JSON_UNESCAPED_UNICODE);
+}
+
+function handleGenerateReport(PDO $db): void
+{
+    $month = max(1, min(12, (int) ($_POST['month'] ?? date('n'))));
+    $year = (int) ($_POST['year'] ?? date('Y'));
+
+    [$startDate, $endDate] = monthBounds($year, $month);
+    $participants = fetchParticipants($db);
+
+    log_info('Формирование отчета за месяц', [
+        'month' => $month,
+        'year' => $year,
+        'participants' => count($participants),
+    ]);
+
+    if (empty($participants)) {
+        http_response_code(422);
+        echo json_encode(['error' => 'Нет участников для формирования отчета'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $daysInMonth = cal_days_in_month(CAL_GREGORIAN, $month, $year);
+
+    $stmt = $db->prepare(
+        "SELECT id, participant_id, type, start_date, end_date FROM events WHERE type IN ('duty', 'vacation', 'trip', 'sick', 'study') AND NOT (date(end_date) < :start OR date(start_date) > :end)"
+    );
+    $stmt->execute([
+        ':start' => $startDate,
+        ':end' => $endDate,
+    ]);
+
+    $rangeMeta = [
+        'vacation' => ['label' => 'Отпуск', 'fill' => 'FFF59D'],
+        'trip' => ['label' => 'Командировка', 'fill' => 'E9D5FF'],
+        'sick' => ['label' => 'Больничный', 'fill' => 'BFDBFE'],
+        'study' => ['label' => 'Учеба', 'fill' => 'CFFAFE'],
+    ];
+
+    $grid = [];
+    while ($event = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $pid = (int) $event['participant_id'];
+        if (!isset($grid[$pid])) {
+            $grid[$pid] = [];
+        }
+
+        $start = new DateTimeImmutable($event['start_date']);
+        $end = new DateTimeImmutable($event['end_date']);
+        for ($cursor = $start; $cursor <= $end; $cursor = $cursor->modify('+1 day')) {
+            $current = $cursor->format('Y-m-d');
+            if ($current < $startDate || $current > $endDate) {
+                continue;
+            }
+
+            $cellData = [
+                'type' => $event['type'],
+                'event_id' => (int) $event['id'],
+            ];
+
+            if (isset($rangeMeta[$event['type']])) {
+                if (!isset($grid[$pid][$current])) {
+                    $cellData['text'] = $rangeMeta[$event['type']]['label'];
+                    $grid[$pid][$current] = $cellData;
+                }
+            } elseif ($event['type'] === 'duty') {
+                $cellData['text'] = 'Х';
+                $grid[$pid][$current] = $cellData;
+            }
+        }
+    }
+
+    $weekendFill = 'C6F6D5';
+
+    $headers = [[
+        'text' => 'ФИО',
+        'bold' => true,
+        'alignment' => 'left',
+        'header' => true,
+    ]];
+
+    $weekendMap = [];
+    for ($day = 1; $day <= $daysInMonth; $day++) {
+        $dateKey = sprintf('%04d-%02d-%02d', $year, $month, $day);
+        $date = DateTimeImmutable::createFromFormat('Y-m-d', $dateKey);
+        $isWeekend = $date && ((int) $date->format('N') >= 6);
+        $weekendMap[$day] = $isWeekend;
+
+        $headerCell = [
+            'text' => (string) $day,
+            'bold' => true,
+            'alignment' => 'center',
+            'header' => true,
+        ];
+
+        if ($isWeekend) {
+            $headerCell['shading'] = $weekendFill;
+        }
+
+        $headers[] = $headerCell;
+    }
+
+    $rows = [];
+    foreach ($participants as $participant) {
+        $pid = (int) $participant['id'];
+        $row = [[
+            'text' => $participant['name'],
+            'alignment' => 'left',
+        ]];
+
+        $day = 1;
+        while ($day <= $daysInMonth) {
+            $dateKey = sprintf('%04d-%02d-%02d', $year, $month, $day);
+            $cellEvent = $grid[$pid][$dateKey] ?? null;
+
+            if (is_array($cellEvent) && isset($rangeMeta[$cellEvent['type']])) {
+                $eventId = $cellEvent['event_id'];
+                $eventType = $cellEvent['type'];
+                $span = 1;
+
+                for ($cursor = $day + 1; $cursor <= $daysInMonth; $cursor++) {
+                    $nextKey = sprintf('%04d-%02d-%02d', $year, $month, $cursor);
+                    $nextEvent = $grid[$pid][$nextKey] ?? null;
+                    if (!is_array($nextEvent) || $nextEvent['type'] !== $eventType || $nextEvent['event_id'] !== $eventId) {
+                        break;
+                    }
+                    $span++;
+                }
+
+                $row[] = [
+                    'text' => $rangeMeta[$eventType]['label'],
+                    'alignment' => 'center',
+                    'span' => $span,
+                    'shading' => $rangeMeta[$eventType]['fill'],
+                ];
+
+                for ($i = 1; $i < $span; $i++) {
+                    $row[] = ['skip' => true];
+                }
+
+                $day += $span;
+                continue;
+            }
+
+            $text = '';
+            if (is_array($cellEvent) && $cellEvent['type'] === 'duty') {
+                $text = 'Х';
+            }
+
+            $cell = [
+                'text' => $text,
+                'alignment' => 'center',
+            ];
+
+            if (!empty($weekendMap[$day])) {
+                $cell['shading'] = $weekendFill;
+            }
+
+            $row[] = $cell;
+            $day++;
+        }
+
+        $rows[] = $row;
+    }
+
+    if (!class_exists('ZipArchive')) {
+        log_error('Формирование отчета невозможно — отсутствует ZipArchive');
+        http_response_code(500);
+        echo json_encode(['error' => 'ZipArchive недоступен на сервере'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    try {
+        $filePath = createDutyReportDocx($headers, $rows, $year, $month);
+    } catch (Throwable $e) {
+        log_error('Не удалось сформировать DOCX-отчет', [
+            'error' => $e->getMessage(),
+        ]);
+        http_response_code(500);
+        echo json_encode(['error' => 'Не удалось сформировать отчет'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $fileName = sprintf('duty-report-%04d-%02d.docx', $year, $month);
+    $fileSize = @filesize($filePath) ?: null;
+
+    header('Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+    header('Content-Disposition: attachment; filename="' . $fileName . '"');
+    header('Cache-Control: no-store, no-cache, must-revalidate');
+    header('Pragma: no-cache');
+    if ($fileSize !== null) {
+        header('Content-Length: ' . $fileSize);
+    }
+
+    readfile($filePath);
+    unlink($filePath);
+
+    log_info('DOCX-отчет сформирован и отправлен', [
+        'file' => $fileName,
+    ]);
+
+    exit;
+}
+
+function getEditPassword(): string
+{
+    $password = getenv('APP_EDIT_PASSWORD');
+    if ($password !== false && $password !== '') {
+        return (string) $password;
+    }
+
+    return DEFAULT_EDIT_PASSWORD;
+}
+
+function isPasswordValid(?string $value): bool
+{
+    $expected = (string) getEditPassword();
+    $provided = trim((string) $value);
+
+    if ($expected === '') {
+        return $provided === '';
+    }
+
+    return hash_equals($expected, $provided);
+}
+
+function requireValidPassword(?string $value, string $action): bool
+{
+    if (!isPasswordValid($value)) {
+        log_warning('Неверный пароль для действия', [
+            'action' => $action,
+        ]);
+        http_response_code(403);
+        echo json_encode(['error' => 'Неверный пароль'], JSON_UNESCAPED_UNICODE);
+        return false;
+    }
+
+    return true;
+}
+
+function isMonthLocked(PDO $db, int $year, int $month): bool
+{
+    $stmt = $db->prepare('SELECT approved FROM approvals WHERE year = :year AND month = :month LIMIT 1');
+    $stmt->execute([
+        ':year' => $year,
+        ':month' => $month,
+    ]);
+
+    return (bool) $stmt->fetchColumn();
+}
+
+function setMonthLocked(PDO $db, int $year, int $month, bool $locked): void
+{
+    $stmt = $db->prepare(
+        'INSERT INTO approvals (year, month, approved, approved_at)
+         VALUES (:year, :month, :approved, CASE WHEN :approved = 1 THEN CURRENT_TIMESTAMP ELSE NULL END)
+         ON CONFLICT(year, month) DO UPDATE SET
+            approved = excluded.approved,
+            approved_at = CASE WHEN excluded.approved = 1 THEN CURRENT_TIMESTAMP ELSE NULL END'
+    );
+    $stmt->execute([
+        ':year' => $year,
+        ':month' => $month,
+        ':approved' => $locked ? 1 : 0,
+    ]);
+}
+
+function getLockedMonthsInRange(PDO $db, string $start, string $end): array
+{
+    $startDate = DateTimeImmutable::createFromFormat('Y-m-d', $start);
+    $endDate = DateTimeImmutable::createFromFormat('Y-m-d', $end);
+    if (!$startDate || !$endDate) {
+        return [];
+    }
+
+    $cursor = new DateTimeImmutable($startDate->format('Y-m-01'));
+    $endCursor = new DateTimeImmutable($endDate->format('Y-m-01'));
+    $locked = [];
+
+    while ($cursor <= $endCursor) {
+        $year = (int) $cursor->format('Y');
+        $month = (int) $cursor->format('n');
+        if (isMonthLocked($db, $year, $month)) {
+            $locked[] = ['year' => $year, 'month' => $month];
+        }
+        $cursor = $cursor->modify('+1 month');
+    }
+
+    return $locked;
+}
+
+function respondLocked(array $lockedMonths): void
+{
+    http_response_code(423);
+
+    if (!empty($lockedMonths)) {
+        $first = $lockedMonths[0];
+        $message = sprintf(
+            'Месяц %s %d утвержден и недоступен для редактирования.',
+            monthNameRu((int) $first['month']),
+            (int) $first['year']
+        );
+    } else {
+        $message = 'Месяц утвержден и недоступен для редактирования.';
+    }
+
+    echo json_encode(['error' => $message], JSON_UNESCAPED_UNICODE);
+}
+
+function fetchParticipants(PDO $db): array
+{
+    $stmt = $db->query('SELECT id, name FROM participants ORDER BY sort_order, id');
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function monthBounds(int $year, int $month): array
+{
+    $start = sprintf('%04d-%02d-01', $year, $month);
+    $days = cal_days_in_month(CAL_GREGORIAN, $month, $year);
+    $end = sprintf('%04d-%02d-%02d', $year, $month, $days);
+    return [$start, $end];
+}
+
+function validateDate(string $value): bool
+{
+    $date = DateTime::createFromFormat('Y-m-d', $value);
+    return $date && $date->format('Y-m-d') === $value;
+}
+
+function areConsecutiveDates(string $previous, string $current): bool
+{
+    $prev = DateTimeImmutable::createFromFormat('Y-m-d', $previous);
+    $curr = DateTimeImmutable::createFromFormat('Y-m-d', $current);
+    if (!$prev || !$curr) {
+        return false;
+    }
+
+    return $prev->modify('+1 day')->format('Y-m-d') === $curr->format('Y-m-d');
+}
+
+function createDutyReportDocx(array $headers, array $rows, int $year, int $month): string
+{
+    $title = sprintf('График дежурств — %s %d', monthNameRu($month), $year);
+    $documentXml = buildReportDocumentXml($title, $headers, $rows);
+
+    $tmpFile = createReportTempFile();
+
+    $zip = new ZipArchive();
+    $opened = $zip->open($tmpFile, ZipArchive::OVERWRITE | ZipArchive::CREATE);
+
+    if ($opened !== true) {
+        @unlink($tmpFile);
+        throw new RuntimeException('Не удалось открыть архив для отчета');
+    }
+
+    $zip->addFromString('[Content_Types].xml', getDocxContentTypesXml());
+    $zip->addFromString('_rels/.rels', getDocxRelsXml());
+    $zip->addFromString('word/document.xml', $documentXml);
+    $zip->addFromString('word/styles.xml', getDocxStylesXml());
+    $zip->addFromString('word/_rels/document.xml.rels', getDocxDocumentRelsXml());
+    $zip->close();
+
+    return $tmpFile;
+}
+
+function createReportTempFile(): string
+{
+    $directories = [];
+
+    $customDir = trim((string) (getenv('APP_REPORT_TEMP_DIR') ?: ''));
+    if ($customDir !== '') {
+        if (!preg_match('/^(?:[a-zA-Z]:\\\\|\\\\\\\\|\/)/', $customDir)) {
+            $customDir = __DIR__ . DIRECTORY_SEPARATOR . $customDir;
+        }
+        $directories[] = $customDir;
+    }
+
+    $directories[] = __DIR__ . DIRECTORY_SEPARATOR . 'data';
+    $directories[] = __DIR__ . DIRECTORY_SEPARATOR . 'App_Data';
+    $directories[] = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'work-calendar';
+    $directories[] = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR);
+
+    $attempted = [];
+
+    foreach ($directories as $dir) {
+        $dir = rtrim($dir, "\\/");
+        if ($dir === '' || isset($attempted[$dir])) {
+            continue;
+        }
+        $attempted[$dir] = true;
+
+        if (!ensureDirectoryWritable($dir)) {
+            log_warning('Каталог недоступен для временного файла отчета', [
+                'directory' => $dir,
+            ]);
+            continue;
+        }
+
+        for ($attempt = 0; $attempt < 5; $attempt++) {
+            $candidate = $dir . DIRECTORY_SEPARATOR . generateReportFileName();
+
+            $handle = @fopen($candidate, 'xb');
+            if ($handle === false) {
+                if (file_exists($candidate)) {
+                    continue;
+                }
+
+                log_warning('Не удалось зарезервировать файл для отчета', [
+                    'directory' => $dir,
+                    'path' => $candidate,
+                ]);
+                break;
+            }
+
+            fclose($handle);
+
+            log_info('Зарезервирован файл для отчета', [
+                'directory' => $dir,
+                'file' => $candidate,
+            ]);
+
+            return $candidate;
+        }
+    }
+
+    throw new RuntimeException('Не удалось создать временный файл для отчета');
+}
+
+function generateReportFileName(): string
+{
+    $timestamp = date('Ymd_His');
+
+    try {
+        $random = bin2hex(random_bytes(6));
+    } catch (Throwable $e) {
+        $random = substr(md5(uniqid((string) getmypid(), true)), 0, 12);
+    }
+
+    return sprintf('duty_report_%s_%s.docx', $timestamp, $random);
+}
+
+function buildReportDocumentXml(string $title, array $headers, array $rows): string
+{
+    $columnCount = max(1, count($headers));
+    $tableWidthTwips = 14500; // ширина страницы за вычетом полей в twips
+    $firstColumnWidth = 3200;
+    if ($columnCount === 1) {
+        $columnWidths = [$tableWidthTwips];
+    } else {
+        $remainingWidth = max($tableWidthTwips - $firstColumnWidth, 2000);
+        $otherColumnCount = $columnCount - 1;
+        $baseWidth = intdiv($remainingWidth, $otherColumnCount);
+        $columnWidths = [$firstColumnWidth];
+
+        for ($i = 0; $i < $otherColumnCount; $i++) {
+            $columnWidths[] = $baseWidth;
+        }
+
+        $allocated = array_sum($columnWidths);
+        $delta = $tableWidthTwips - $allocated;
+        if ($delta !== 0) {
+            $columnWidths[count($columnWidths) - 1] += $delta;
+        }
+    }
+
+    $lastColumnWidth = $columnWidths[count($columnWidths) - 1];
+
+    $table = '<w:tbl>'
+        . '<w:tblPr>'
+        . '<w:tblStyle w:val="TableGrid"/>'
+        . '<w:tblW w:w="' . $tableWidthTwips . '" w:type="dxa"/>'
+        . '<w:tblLayout w:type="Fixed"/>'
+        . '<w:tblLook w:val="04A0" w:firstRow="1" w:lastRow="0" w:firstColumn="1" w:lastColumn="0" w:noHBand="0" w:noVBand="0"/>'
+        . '<w:tblBorders>'
+        . '<w:top w:val="single" w:sz="8" w:space="0" w:color="auto"/>'
+        . '<w:left w:val="single" w:sz="8" w:space="0" w:color="auto"/>'
+        . '<w:bottom w:val="single" w:sz="8" w:space="0" w:color="auto"/>'
+        . '<w:right w:val="single" w:sz="8" w:space="0" w:color="auto"/>'
+        . '<w:insideH w:val="single" w:sz="4" w:space="0" w:color="auto"/>'
+        . '<w:insideV w:val="single" w:sz="4" w:space="0" w:color="auto"/>'
+        . '</w:tblBorders>'
+        . '</w:tblPr>'
+        . '<w:tblGrid>';
+
+    foreach ($columnWidths as $width) {
+        $table .= '<w:gridCol w:w="' . $width . '"/>';
+    }
+    $table .= '</w:tblGrid>';
+
+    $table .= '<w:tr><w:trPr><w:tblHeader/></w:trPr>';
+    for ($colIndex = 0; $colIndex < $columnCount; $colIndex++) {
+        $cellData = $headers[$colIndex] ?? [];
+        if (isset($cellData['skip']) && $cellData['skip']) {
+            continue;
+        }
+
+        if (!is_array($cellData)) {
+            $cellData = ['text' => (string) $cellData];
+        }
+
+        if (!isset($cellData['span']) || (int) $cellData['span'] < 1) {
+            $cellData['span'] = 1;
+        }
+
+        $cellData['header'] = $cellData['header'] ?? true;
+        $cellData['bold'] = $cellData['bold'] ?? true;
+
+        $span = (int) $cellData['span'];
+        $width = 0;
+        for ($offset = 0; $offset < $span; $offset++) {
+            $width += $columnWidths[$colIndex + $offset] ?? $lastColumnWidth;
+        }
+
+        $table .= buildTableCellXml($cellData, $width);
+
+        if ($span > 1) {
+            $colIndex += $span - 1;
+        }
+    }
+    $table .= '</w:tr>';
+
+    foreach ($rows as $row) {
+        $table .= '<w:tr>';
+        for ($colIndex = 0; $colIndex < $columnCount; $colIndex++) {
+            $cellData = $row[$colIndex] ?? [];
+            if (isset($cellData['skip']) && $cellData['skip']) {
+                continue;
+            }
+
+            if (!is_array($cellData)) {
+                $cellData = ['text' => (string) $cellData];
+            }
+
+            if (!isset($cellData['span']) || (int) $cellData['span'] < 1) {
+                $cellData['span'] = 1;
+            }
+
+            $cellData['header'] = false;
+            $cellData['bold'] = $cellData['bold'] ?? false;
+
+            $span = (int) $cellData['span'];
+            $width = 0;
+            for ($offset = 0; $offset < $span; $offset++) {
+                $width += $columnWidths[$colIndex + $offset] ?? $lastColumnWidth;
+            }
+
+            $table .= buildTableCellXml($cellData, $width);
+
+            if ($span > 1) {
+                $colIndex += $span - 1;
+            }
+        }
+        $table .= '</w:tr>';
+    }
+
+    $table .= '</w:tbl>';
+
+    $body = '<w:body>'
+        . '<w:p>'
+        . '<w:pPr><w:jc w:val="center"/></w:pPr>'
+        . '<w:r>'
+        . '<w:rPr><w:b/><w:sz w:val="32"/><w:szCs w:val="32"/></w:rPr>'
+        . '<w:t xml:space="preserve">' . docxEscape($title) . '</w:t>'
+        . '</w:r>'
+        . '</w:p>'
+        . $table
+        . '<w:sectPr>'
+        . '<w:pgSz w:w="16838" w:h="11906" w:orient="landscape"/>'
+        . '<w:pgMar w:top="1134" w:right="1134" w:bottom="1134" w:left="1134" w:header="708" w:footer="708" w:gutter="0"/>'
+        . '<w:cols w:space="708"/>'
+        . '<w:docGrid w:linePitch="360"/>'
+        . '</w:sectPr>'
+        . '</w:body>';
+
+    return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        . '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'
+        . ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+        . '>'
+        . $body
+        . '</w:document>';
+}
+
+function buildTableCellXml(array $cell, int $width): string
+{
+    $text = (string) ($cell['text'] ?? '');
+    $bold = !empty($cell['bold']);
+    $alignment = $cell['alignment'] ?? null;
+    $isHeader = !empty($cell['header']);
+    $shading = $cell['shading'] ?? null;
+    $span = max(1, (int) ($cell['span'] ?? 1));
+
+    $tcPrParts = ['<w:tcW w:w="' . max(0, $width) . '" w:type="dxa"/>'];
+
+    if ($span > 1) {
+        $tcPrParts[] = '<w:gridSpan w:val="' . $span . '"/>';
+    }
+
+    if ($shading) {
+        $tcPrParts[] = '<w:shd w:val="clear" w:color="auto" w:fill="' . $shading . '"/>';
+    } elseif ($isHeader) {
+        $tcPrParts[] = '<w:shd w:val="clear" w:color="auto" w:fill="E2E8F0"/>';
+    }
+
+    $tcPr = '<w:tcPr>' . implode('', $tcPrParts) . '</w:tcPr>';
+
+    $pPr = '';
+    if ($alignment !== null && $alignment !== '') {
+        $pPr = '<w:pPr><w:jc w:val="' . $alignment . '"/></w:pPr>';
+    }
+
+    $escaped = docxEscape($text);
+    $runProps = $bold ? '<w:rPr><w:b/><w:bCs/></w:rPr>' : '';
+    $textNode = $escaped === ''
+        ? '<w:t/>'
+        : '<w:t xml:space="preserve">' . $escaped . '</w:t>';
+
+    return '<w:tc>' . $tcPr . '<w:p>' . $pPr . '<w:r>' . $runProps . $textNode . '</w:r></w:p></w:tc>';
+}
+
+function docxEscape(string $text): string
+{
+    return htmlspecialchars($text, ENT_QUOTES | ENT_XML1, 'UTF-8');
+}
+
+function getDocxContentTypesXml(): string
+{
+    return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        . '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+        . '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+        . '<Default Extension="xml" ContentType="application/xml"/>'
+        . '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>'
+        . '<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>'
+        . '</Types>';
+}
+
+function getDocxRelsXml(): string
+{
+    return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        . '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+        . '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>'
+        . '</Relationships>';
+}
+
+function getDocxDocumentRelsXml(): string
+{
+    return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        . '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>';
+}
+
+function getDocxStylesXml(): string
+{
+    return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        . '<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+        . '<w:style w:type="paragraph" w:default="1" w:styleId="Normal">'
+        . '<w:name w:val="Normal"/>'
+        . '<w:qFormat/>'
+        . '</w:style>'
+        . '<w:style w:type="table" w:styleId="TableGrid">'
+        . '<w:name w:val="Table Grid"/>'
+        . '<w:basedOn w:val="TableNormal"/>'
+        . '<w:uiPriority w:val="59"/>'
+        . '<w:tblPr>'
+        . '<w:tblBorders>'
+        . '<w:top w:val="single" w:sz="4" w:space="0" w:color="auto"/>'
+        . '<w:left w:val="single" w:sz="4" w:space="0" w:color="auto"/>'
+        . '<w:bottom w:val="single" w:sz="4" w:space="0" w:color="auto"/>'
+        . '<w:right w:val="single" w:sz="4" w:space="0" w:color="auto"/>'
+        . '<w:insideH w:val="single" w:sz="4" w:space="0" w:color="auto"/>'
+        . '<w:insideV w:val="single" w:sz="4" w:space="0" w:color="auto"/>'
+        . '</w:tblBorders>'
+        . '</w:tblPr>'
+        . '</w:style>'
+        . '</w:styles>';
+}
+
+function monthNameRu(int $month): string
+{
+    $months = [
+        1 => 'Январь',
+        2 => 'Февраль',
+        3 => 'Март',
+        4 => 'Апрель',
+        5 => 'Май',
+        6 => 'Июнь',
+        7 => 'Июль',
+        8 => 'Август',
+        9 => 'Сентябрь',
+        10 => 'Октябрь',
+        11 => 'Ноябрь',
+        12 => 'Декабрь',
+    ];
+
+    return $months[$month] ?? '';
+}

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,0 +1,902 @@
+(function () {
+    const page = document.body.dataset.page;
+    if (page === 'home') {
+        initCalendarPage();
+    } else if (page === 'stats') {
+        initStatsPage();
+    }
+
+    function initCalendarPage() {
+        const LOCK_MESSAGE = 'Месяц утвержден. Редактирование недоступно.';
+
+        const state = {
+            month: new Date().getMonth() + 1,
+            year: new Date().getFullYear(),
+            editing: false,
+            locked: false,
+            participants: [],
+            events: [],
+            pendingRange: null,
+        };
+
+        const calendarContainer = document.getElementById('calendar-container');
+        const currentMonthEl = document.getElementById('current-month');
+        const prevMonthBtn = document.getElementById('prev-month');
+        const nextMonthBtn = document.getElementById('next-month');
+        const editToggle = document.getElementById('edit-toggle');
+        const approvalToggle = document.getElementById('approval-toggle');
+        const addParticipantBtn = document.getElementById('add-participant');
+        const infoMessage = document.getElementById('info-message');
+        const distributeBtn = document.getElementById('distribute');
+        const clearDutiesBtn = document.getElementById('clear-duty');
+        const reportBtn = document.getElementById('generate-report');
+        const eventMenu = document.getElementById('event-menu');
+        const modal = createModal();
+
+        const editLabel = editToggle ? editToggle.closest('label') : null;
+        const approvalLabel = approvalToggle ? approvalToggle.closest('label') : null;
+
+        const eventLabels = {
+            duty: 'Х',
+            important: 'о',
+            vacation: 'Отпуск',
+            trip: 'Командировка',
+            sick: 'Больничный',
+            study: 'Учеба',
+        };
+
+        const rangeTypes = ['vacation', 'trip', 'sick', 'study'];
+
+        updateControlsState();
+        loadCalendar();
+
+        prevMonthBtn.addEventListener('click', () => {
+            changeMonth(-1);
+        });
+        nextMonthBtn.addEventListener('click', () => {
+            changeMonth(1);
+        });
+        editToggle.addEventListener('change', (event) => {
+            if (state.locked) {
+                event.target.checked = false;
+                updateControlsState();
+                return;
+            }
+
+            state.editing = event.target.checked;
+            if (!state.editing) {
+                clearPendingRange();
+                hideEventMenu();
+                if (infoMessage.textContent === LOCK_MESSAGE) {
+                    infoMessage.textContent = '';
+                }
+            }
+
+            updateControlsState();
+            renderCalendar();
+        });
+        if (approvalToggle) {
+            approvalToggle.addEventListener('change', () => {
+                if (approvalToggle.disabled) {
+                    return;
+                }
+
+                const previousState = state.locked;
+                const targetState = approvalToggle.checked;
+                if (previousState === targetState) {
+                    return;
+                }
+
+                if (!targetState) {
+                    const password = requestPassword('Введите пароль для снятия утверждения');
+                    if (password === null) {
+                        approvalToggle.checked = previousState;
+                        return;
+                    }
+                    if (password === '') {
+                        infoMessage.textContent = 'Пароль не может быть пустым.';
+                        approvalToggle.checked = previousState;
+                        return;
+                    }
+                    setMonthApproval(false, password);
+                } else {
+                    setMonthApproval(true);
+                }
+            });
+        }
+        addParticipantBtn.addEventListener('click', () => {
+            if (!state.editing) return;
+            const name = prompt('Введите фамилию участника');
+            if (name) {
+                addParticipant(name.trim());
+            }
+        });
+        distributeBtn.addEventListener('click', handleAutoAssign);
+        if (clearDutiesBtn) {
+            clearDutiesBtn.addEventListener('click', handleClearDuties);
+        }
+        if (reportBtn) {
+            reportBtn.addEventListener('click', handleReportDownload);
+        }
+
+        document.addEventListener('click', (event) => {
+            if (eventMenu.classList.contains('hidden')) {
+                return;
+            }
+            if (!eventMenu.contains(event.target)) {
+                hideEventMenu();
+            }
+        });
+
+        Array.from(eventMenu.querySelectorAll('button')).forEach((button) => {
+            button.addEventListener('click', () => {
+                const type = button.dataset.type;
+                const { participantId, date } = eventMenu.dataset;
+                hideEventMenu();
+                handleEventCreation(type, participantId, date);
+            });
+        });
+
+        function updateControlsState() {
+            if (editToggle) {
+                if (state.locked) {
+                    if (state.editing) {
+                        state.editing = false;
+                    }
+                    editToggle.checked = false;
+                    editToggle.disabled = true;
+                    if (editLabel) {
+                        editLabel.classList.add('disabled');
+                    }
+                } else {
+                    editToggle.disabled = false;
+                    if (editLabel) {
+                        editLabel.classList.remove('disabled');
+                    }
+                    editToggle.checked = state.editing;
+                }
+            }
+
+            if (approvalToggle && !approvalToggle.disabled) {
+                approvalToggle.checked = state.locked;
+            }
+
+            if (state.locked) {
+                if (!infoMessage.textContent || infoMessage.textContent === LOCK_MESSAGE) {
+                    infoMessage.textContent = LOCK_MESSAGE;
+                }
+            } else if (infoMessage.textContent === LOCK_MESSAGE) {
+                infoMessage.textContent = '';
+            }
+
+            const showEditingActions = state.editing && !state.locked;
+            [distributeBtn, clearDutiesBtn, addParticipantBtn].forEach((btn) => {
+                if (btn) {
+                    btn.classList.toggle('hidden', !showEditingActions);
+                }
+            });
+        }
+
+        function requestPassword(message) {
+            const input = prompt(message);
+            if (input === null) {
+                return null;
+            }
+            return input.trim();
+        }
+
+        function parseJsonResponse(response, defaultMessage) {
+            const contentType = response.headers.get('Content-Type') || '';
+            if (!response.ok) {
+                if (contentType.includes('application/json')) {
+                    return response.json().then((data) => {
+                        throw new Error(data.error || defaultMessage);
+                    });
+                }
+                throw new Error(defaultMessage);
+            }
+            return response.json();
+        }
+
+        function setMonthApproval(approved, password) {
+            if (!approvalToggle) {
+                return;
+            }
+
+            approvalToggle.disabled = true;
+            if (approvalLabel) {
+                approvalLabel.classList.add('disabled');
+            }
+
+            const formData = new FormData();
+            formData.append('action', 'set_month_approval');
+            formData.append('month', state.month);
+            formData.append('year', state.year);
+            formData.append('approved', approved ? 'true' : 'false');
+            if (typeof password === 'string') {
+                formData.append('password', password);
+            }
+
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            })
+                .then((response) => parseJsonResponse(response, 'Не удалось обновить статус месяца.'))
+                .then((data) => {
+                    state.locked = Boolean(data.locked);
+                    if (state.locked) {
+                        state.editing = false;
+                        clearPendingRange();
+                        hideEventMenu();
+                        infoMessage.textContent = LOCK_MESSAGE;
+                    } else {
+                        infoMessage.textContent = 'Редактирование снова доступно.';
+                    }
+                    approvalToggle.checked = state.locked;
+                    updateControlsState();
+                    renderCalendar();
+                })
+                .catch((error) => {
+                    infoMessage.textContent = error.message || 'Не удалось обновить статус месяца.';
+                    approvalToggle.checked = state.locked;
+                    updateControlsState();
+                })
+                .finally(() => {
+                    approvalToggle.disabled = false;
+                    if (approvalLabel) {
+                        approvalLabel.classList.remove('disabled');
+                    }
+                });
+        }
+
+        function changeMonth(delta) {
+            state.month += delta;
+            if (state.month < 1) {
+                state.month = 12;
+                state.year -= 1;
+            } else if (state.month > 12) {
+                state.month = 1;
+                state.year += 1;
+            }
+            clearPendingRange();
+            infoMessage.textContent = '';
+            loadCalendar();
+        }
+
+        function loadCalendar() {
+            const formData = new FormData();
+            formData.append('action', 'get_calendar');
+            formData.append('month', String(state.month));
+            formData.append('year', String(state.year));
+
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            })
+                .then((response) => response.json())
+                .then((data) => {
+                    state.participants = data.participants || [];
+                    state.events = data.events || [];
+                    const locked = Boolean(data.locked);
+                    if (locked !== state.locked) {
+                        state.locked = locked;
+                        if (state.locked) {
+                            state.editing = false;
+                            clearPendingRange();
+                            hideEventMenu();
+                        }
+                    }
+                    updateControlsState();
+                    renderCalendar();
+                })
+                .catch(() => {
+                    infoMessage.textContent = 'Не удалось загрузить данные.';
+                });
+        }
+
+        function renderCalendar() {
+            updateControlsState();
+            const date = new Date(state.year, state.month - 1, 1);
+            currentMonthEl.textContent = date.toLocaleString('ru-RU', {
+                month: 'long',
+                year: 'numeric',
+            });
+
+            calendarContainer.innerHTML = '';
+            const table = document.createElement('table');
+            table.className = 'calendar-table';
+
+            const thead = document.createElement('thead');
+            const headerRow = document.createElement('tr');
+            const nameHeader = document.createElement('th');
+            nameHeader.textContent = 'ФИО';
+            headerRow.appendChild(nameHeader);
+
+            const daysInMonth = new Date(state.year, state.month, 0).getDate();
+            for (let day = 1; day <= daysInMonth; day++) {
+                const th = document.createElement('th');
+                th.textContent = day;
+                const dateKey = formatDate(state.year, state.month, day);
+                if (isWeekend(dateKey)) {
+                    th.classList.add('weekend');
+                }
+                headerRow.appendChild(th);
+            }
+            thead.appendChild(headerRow);
+            table.appendChild(thead);
+
+            const tbody = document.createElement('tbody');
+            const eventMap = buildEventMap();
+
+            state.participants.forEach((participant, index) => {
+                const row = document.createElement('tr');
+                const nameCell = document.createElement('td');
+                nameCell.textContent = participant.name;
+                if (state.editing) {
+                    const actions = document.createElement('div');
+                    actions.className = 'participant-actions';
+
+                    const upBtn = document.createElement('button');
+                    upBtn.textContent = '▲';
+                    upBtn.title = 'Выше';
+                    upBtn.addEventListener('click', () => moveParticipant(index, -1));
+
+                    const downBtn = document.createElement('button');
+                    downBtn.textContent = '▼';
+                    downBtn.title = 'Ниже';
+                    downBtn.addEventListener('click', () => moveParticipant(index, 1));
+
+                    const removeBtn = document.createElement('button');
+                    removeBtn.textContent = '✖';
+                    removeBtn.title = 'Удалить';
+                    removeBtn.addEventListener('click', () => deleteParticipant(participant.id));
+
+                    if (index === 0) {
+                        upBtn.disabled = true;
+                    }
+                    if (index === state.participants.length - 1) {
+                        downBtn.disabled = true;
+                    }
+
+                    actions.append(upBtn, downBtn, removeBtn);
+                    nameCell.appendChild(actions);
+                }
+                row.appendChild(nameCell);
+
+                for (let day = 1; day <= daysInMonth; day++) {
+                    const cell = document.createElement('td');
+                    const dateKey = formatDate(state.year, state.month, day);
+                    cell.dataset.date = dateKey;
+                    cell.dataset.participantId = participant.id;
+
+                    if (isWeekend(dateKey)) {
+                        cell.classList.add('weekend');
+                    }
+
+                    const eventInfo = (eventMap[participant.id] || {})[dateKey];
+                    if (eventInfo) {
+                        const { event, isStart, isEnd } = eventInfo;
+                        cell.dataset.eventId = event.id;
+                        cell.classList.add('has-event');
+                        cell.classList.add('event-' + event.type);
+                        cell.title = eventLabels[event.type] || '';
+
+                        if (event.type === 'duty') {
+                            cell.textContent = eventLabels.duty;
+                        } else if (event.type === 'important') {
+                            cell.textContent = eventLabels.important;
+                        } else if (rangeTypes.includes(event.type)) {
+                            cell.classList.add('range-' + event.type);
+                            if (isStart) {
+                                cell.classList.add('range-start');
+                                cell.textContent = eventLabels[event.type];
+                            } else if (isEnd) {
+                                cell.classList.add('range-end');
+                            } else {
+                                cell.classList.add('range-middle');
+                            }
+                        }
+                    } else {
+                        cell.classList.add('editable');
+                    }
+
+                    cell.addEventListener('click', (event) => handleCellClick(event, cell));
+                    row.appendChild(cell);
+                }
+
+                tbody.appendChild(row);
+            });
+
+            table.appendChild(tbody);
+            calendarContainer.appendChild(table);
+        }
+
+        function buildEventMap() {
+            const map = {};
+            state.events.forEach((event) => {
+                if (!map[event.participant_id]) {
+                    map[event.participant_id] = {};
+                }
+                const start = new Date(event.start_date);
+                const end = new Date(event.end_date);
+                for (let date = new Date(start); date <= end; date.setDate(date.getDate() + 1)) {
+                    const year = date.getFullYear();
+                    const month = date.getMonth() + 1;
+                    if (year !== state.year || month !== state.month) {
+                        continue;
+                    }
+                    const day = date.getDate();
+                    const dateKey = formatDate(year, month, day);
+                    map[event.participant_id][dateKey] = {
+                        event,
+                        isStart: dateKey === event.start_date,
+                        isEnd: dateKey === event.end_date,
+                    };
+                }
+            });
+            return map;
+        }
+
+        function handleCellClick(event, cell) {
+            event.stopPropagation();
+            if (!state.editing) {
+                return;
+            }
+
+            const eventId = cell.dataset.eventId;
+            const participantId = cell.dataset.participantId;
+            const date = cell.dataset.date;
+
+            if (state.pendingRange) {
+                if (state.pendingRange.participantId !== participantId) {
+                    infoMessage.textContent = 'Выберите окончание в той же строке.';
+                    return;
+                }
+                if (date <= state.pendingRange.startDate) {
+                    infoMessage.textContent = 'Дата окончания должна быть позже.';
+                    return;
+                }
+                saveEvent(participantId, state.pendingRange.type, state.pendingRange.startDate, date);
+                clearPendingRange();
+                return;
+            }
+
+            if (eventId) {
+                modal
+                    .confirm('Удалить выбранное событие?')
+                    .then((confirmed) => {
+                        if (confirmed) {
+                            deleteEvent(eventId);
+                        }
+                    });
+                return;
+            }
+
+            showEventMenu(cell, participantId, date, event);
+        }
+
+        function showEventMenu(cell, participantId, date, originalEvent) {
+            const rect = cell.getBoundingClientRect();
+            eventMenu.style.top = `${rect.bottom + window.scrollY}px`;
+            eventMenu.style.left = `${rect.left + window.scrollX}px`;
+            eventMenu.dataset.participantId = participantId;
+            eventMenu.dataset.date = date;
+            eventMenu.classList.remove('hidden');
+        }
+
+        function hideEventMenu() {
+            eventMenu.classList.add('hidden');
+            delete eventMenu.dataset.participantId;
+            delete eventMenu.dataset.date;
+        }
+
+        function handleEventCreation(type, participantId, date) {
+            if (rangeTypes.includes(type)) {
+                state.pendingRange = {
+                    type,
+                    participantId,
+                    startDate: date,
+                };
+                const cell = findCell(participantId, date);
+                if (cell) {
+                    cell.classList.add('pending-selection');
+                }
+                infoMessage.textContent = 'Выберите день окончания события в той же строке.';
+                return;
+            }
+
+            saveEvent(participantId, type, date, date);
+        }
+
+        function findCell(participantId, date) {
+            return calendarContainer.querySelector(`td[data-participant-id="${participantId}"][data-date="${date}"]`);
+        }
+
+        function clearPendingRange() {
+            if (state.pendingRange) {
+                const cell = findCell(state.pendingRange.participantId, state.pendingRange.startDate);
+                if (cell) {
+                    cell.classList.remove('pending-selection');
+                }
+            }
+            state.pendingRange = null;
+        }
+
+        function addParticipant(name) {
+            const formData = new FormData();
+            formData.append('action', 'add_participant');
+            formData.append('name', name);
+
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            })
+                .then((response) => response.json())
+                .then(() => {
+                    loadCalendar();
+                })
+                .catch(() => {
+                    infoMessage.textContent = 'Не удалось добавить участника.';
+                });
+        }
+
+        function deleteParticipant(id) {
+            modal
+                .confirm('Удалить участника и все его события?')
+                .then((confirmed) => {
+                    if (!confirmed) return;
+                    const formData = new FormData();
+                    formData.append('action', 'delete_participant');
+                    formData.append('id', id);
+                    fetch('api.php', {
+                        method: 'POST',
+                        body: formData,
+                    })
+                        .then((response) => response.json())
+                        .then(() => {
+                            loadCalendar();
+                        })
+                        .catch(() => {
+                            infoMessage.textContent = 'Не удалось удалить участника.';
+                        });
+                });
+        }
+
+        function moveParticipant(index, delta) {
+            const newIndex = index + delta;
+            if (newIndex < 0 || newIndex >= state.participants.length) {
+                return;
+            }
+            const reordered = [...state.participants];
+            const [moved] = reordered.splice(index, 1);
+            reordered.splice(newIndex, 0, moved);
+            state.participants = reordered;
+            renderCalendar();
+            saveParticipantOrder();
+        }
+
+        function saveParticipantOrder() {
+            const formData = new FormData();
+            formData.append('action', 'reorder_participants');
+            state.participants.forEach((participant) => {
+                formData.append('order[]', participant.id);
+            });
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            }).catch(() => {
+                infoMessage.textContent = 'Не удалось сохранить порядок участников.';
+            });
+        }
+
+        function saveEvent(participantId, type, startDate, endDate) {
+            const formData = new FormData();
+            formData.append('action', 'save_event');
+            formData.append('participant_id', participantId);
+            formData.append('type', type);
+            formData.append('start_date', startDate);
+            formData.append('end_date', endDate);
+
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            })
+                .then((response) => {
+                    if (!response.ok) {
+                        return response.json().then((data) => {
+                            throw new Error(data.error || 'Ошибка сохранения события');
+                        });
+                    }
+                    return response.json();
+                })
+                .then(() => {
+                    infoMessage.textContent = '';
+                    loadCalendar();
+                })
+                .catch((error) => {
+                    infoMessage.textContent = error.message;
+                    clearPendingRange();
+                });
+        }
+
+        function deleteEvent(eventId) {
+            const formData = new FormData();
+            formData.append('action', 'delete_event');
+            formData.append('id', eventId);
+
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            })
+                .then(() => {
+                    loadCalendar();
+                })
+                .catch(() => {
+                    infoMessage.textContent = 'Не удалось удалить событие.';
+                });
+        }
+
+        function handleAutoAssign() {
+            const password = requestPassword('Введите пароль для распределения дежурств');
+            if (password === null) {
+                return;
+            }
+            if (password === '') {
+                infoMessage.textContent = 'Пароль не может быть пустым.';
+                return;
+            }
+
+            infoMessage.textContent = 'Выполняется распределение дежурств…';
+            submitAutoAssign(password, false);
+        }
+
+        function submitAutoAssign(password, force) {
+            const formData = new FormData();
+            formData.append('action', 'auto_assign');
+            formData.append('month', state.month);
+            formData.append('year', state.year);
+            formData.append('force', force ? 'true' : 'false');
+            formData.append('password', password);
+
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            })
+                .then((response) => parseJsonResponse(response, 'Не удалось распределить дежурства.'))
+                .then((data) => {
+                    if (data.needs_confirm) {
+                        infoMessage.textContent = 'За выбранный месяц уже есть дежурства.';
+                        modal.confirm('Перезаписать существующие дежурства?').then((confirmed) => {
+                            if (!confirmed) return;
+                            infoMessage.textContent = 'Перераспределение дежурств…';
+                            submitAutoAssign(password, true);
+                        });
+                        return;
+                    }
+
+                    handleAutoAssignResult(data);
+                })
+                .catch((error) => {
+                    infoMessage.textContent = error.message || 'Не удалось распределить дежурства.';
+                });
+        }
+
+        function handleAutoAssignResult(data) {
+            if (data.skipped && data.skipped.length > 0) {
+                infoMessage.textContent = 'Не удалось назначить дежурство на дни: ' + data.skipped.join(', ');
+            } else {
+                infoMessage.textContent = 'Дежурства успешно распределены.';
+            }
+            loadCalendar();
+        }
+
+        function handleClearDuties() {
+            modal.confirm('Удалить все дежурства за выбранный месяц?').then((confirmed) => {
+                if (!confirmed) return;
+                const password = requestPassword('Введите пароль для очистки дежурств');
+                if (password === null) {
+                    return;
+                }
+                if (password === '') {
+                    infoMessage.textContent = 'Пароль не может быть пустым.';
+                    return;
+                }
+                const formData = new FormData();
+                formData.append('action', 'clear_month_duties');
+                formData.append('month', state.month);
+                formData.append('year', state.year);
+                formData.append('password', password);
+
+                infoMessage.textContent = 'Очистка дежурств…';
+
+                fetch('api.php', {
+                    method: 'POST',
+                    body: formData,
+                })
+                    .then((response) => parseJsonResponse(response, 'Не удалось очистить дежурства.'))
+                    .then((data) => {
+                        const count = Number(data.cleared || 0);
+                        infoMessage.textContent = count > 0
+                            ? 'Все дежурства текущего месяца удалены.'
+                            : 'За выбранный месяц не найдено дежурств.';
+                        loadCalendar();
+                    })
+                    .catch((error) => {
+                        infoMessage.textContent = error.message || 'Не удалось очистить дежурства.';
+                    });
+            });
+        }
+
+        function handleReportDownload() {
+            const formData = new FormData();
+            formData.append('action', 'generate_report');
+            formData.append('month', state.month);
+            formData.append('year', state.year);
+
+            infoMessage.textContent = 'Формируется отчет…';
+
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            })
+                .then((response) => {
+                    const contentType = response.headers.get('Content-Type') || '';
+                    if (!response.ok) {
+                        if (contentType.includes('application/json')) {
+                            return response.json().then((data) => {
+                                throw new Error(data.error || 'Не удалось сформировать отчет.');
+                            });
+                        }
+                        throw new Error('Не удалось сформировать отчет.');
+                    }
+                    return response.blob();
+                })
+                .then((blob) => {
+                    const url = URL.createObjectURL(blob);
+                    const link = document.createElement('a');
+                    const month = String(state.month).padStart(2, '0');
+                    link.href = url;
+                    link.download = `График-${state.year}-${month}.docx`;
+                    document.body.appendChild(link);
+                    link.click();
+                    document.body.removeChild(link);
+                    setTimeout(() => URL.revokeObjectURL(url), 2000);
+                    infoMessage.textContent = 'Отчет сформирован и загружен.';
+                })
+                .catch((error) => {
+                    infoMessage.textContent = error.message || 'Не удалось сформировать отчет.';
+                });
+        }
+    }
+
+    function initStatsPage() {
+        const yearSelect = document.getElementById('stats-year');
+        const tbody = document.getElementById('stats-body');
+        const state = {
+            year: new Date().getFullYear(),
+        };
+
+        yearSelect.addEventListener('change', () => {
+            state.year = parseInt(yearSelect.value, 10);
+            loadStats();
+        });
+
+        loadStats();
+
+        function loadStats() {
+            const formData = new FormData();
+            formData.append('action', 'get_statistics');
+            formData.append('year', state.year);
+
+            fetch('api.php', {
+                method: 'POST',
+                body: formData,
+            })
+                .then((response) => response.json())
+                .then((data) => {
+                    renderStats(data);
+                })
+                .catch(() => {
+                    tbody.innerHTML = '<tr><td colspan="13">Не удалось загрузить статистику</td></tr>';
+                });
+        }
+
+        function renderStats(data) {
+            if (data.years) {
+                yearSelect.innerHTML = '';
+                data.years.forEach((year) => {
+                    const option = document.createElement('option');
+                    option.value = year;
+                    option.textContent = year;
+                    if (parseInt(year, 10) === parseInt(data.year, 10)) {
+                        option.selected = true;
+                    }
+                    yearSelect.appendChild(option);
+                });
+            }
+
+            const weekdayOrder = [1, 2, 3, 4, 5, 6, 0];
+            tbody.innerHTML = '';
+            (data.data || []).forEach((row) => {
+                const tr = document.createElement('tr');
+                const nameCell = document.createElement('td');
+                nameCell.textContent = row.name;
+                tr.appendChild(nameCell);
+
+                weekdayOrder.forEach((weekday) => {
+                    const td = document.createElement('td');
+                    td.textContent = row.weekdays ? row.weekdays[weekday] || 0 : 0;
+                    tr.appendChild(td);
+                });
+
+                ['vacation', 'sick', 'trip', 'study'].forEach((field) => {
+                    const td = document.createElement('td');
+                    td.textContent = row[field] || 0;
+                    tr.appendChild(td);
+                });
+
+                const total = document.createElement('td');
+                total.textContent = row.total || 0;
+                tr.appendChild(total);
+
+                tbody.appendChild(tr);
+            });
+
+            if (!tbody.children.length) {
+                tbody.innerHTML = '<tr><td colspan="13">Нет данных</td></tr>';
+            }
+        }
+    }
+
+    function createModal() {
+        const modal = document.getElementById('confirm-modal');
+        const messageEl = document.getElementById('modal-message');
+        const confirmBtn = document.getElementById('modal-confirm');
+        const cancelBtn = document.getElementById('modal-cancel');
+
+        let resolver = null;
+
+        confirmBtn.addEventListener('click', () => {
+            hideModal(true);
+        });
+        cancelBtn.addEventListener('click', () => {
+            hideModal(false);
+        });
+
+        function showModal(message) {
+            messageEl.textContent = message;
+            modal.classList.remove('hidden');
+            return new Promise((resolve) => {
+                resolver = resolve;
+            });
+        }
+
+        function hideModal(result) {
+            modal.classList.add('hidden');
+            if (resolver) {
+                resolver(result);
+                resolver = null;
+            }
+        }
+
+        return {
+            confirm(message) {
+                return showModal(message);
+            },
+        };
+    }
+
+    function formatDate(year, month, day) {
+        return [
+            year.toString().padStart(4, '0'),
+            month.toString().padStart(2, '0'),
+            day.toString().padStart(2, '0'),
+        ].join('-');
+    }
+
+    function isWeekend(dateString) {
+        const date = new Date(dateString + 'T00:00:00');
+        const day = date.getDay();
+        return day === 0 || day === 6;
+    }
+})();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,666 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+    --gradient-start: #38bdf8;
+    --gradient-middle: #818cf8;
+    --gradient-end: #f472b6;
+    --surface: rgba(255, 255, 255, 0.82);
+    --surface-strong: #ffffff;
+    --border-light: rgba(148, 163, 184, 0.28);
+    --border-strong: rgba(148, 163, 184, 0.45);
+    --text-color: #0f172a;
+    --text-muted: #475569;
+    --accent: #6366f1;
+    --accent-hover: #4f46e5;
+    --accent-light: rgba(99, 102, 241, 0.12);
+    --accent-lighter: rgba(99, 102, 241, 0.08);
+    --success-soft: rgba(34, 197, 94, 0.18);
+    --shadow-lg: 0 28px 55px rgba(15, 23, 42, 0.22);
+    --shadow-md: 0 18px 40px rgba(15, 23, 42, 0.16);
+    --shadow-sm: 0 8px 25px rgba(15, 23, 42, 0.15);
+    --weekend-bg: rgba(16, 185, 129, 0.18);
+    --range-vacation: rgba(251, 191, 36, 0.35);
+    --range-trip: rgba(165, 180, 252, 0.4);
+    --range-sick: rgba(96, 165, 250, 0.35);
+    --range-study: rgba(125, 211, 252, 0.35);
+    --important-color: #ef4444;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: 'Inter', 'Segoe UI', sans-serif;
+    color: var(--text-color);
+    background: linear-gradient(135deg, var(--gradient-start), var(--gradient-middle), var(--gradient-end));
+    background-attachment: fixed;
+    position: relative;
+}
+
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.18), transparent 55%),
+        radial-gradient(circle at 80% 0%, rgba(255, 255, 255, 0.16), transparent 50%);
+    pointer-events: none;
+    z-index: -1;
+}
+
+a {
+    color: inherit;
+}
+
+.site-header {
+    padding: 1.5rem clamp(1rem, 5vw, 3.5rem) 1.2rem;
+}
+
+.top-nav {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    width: 100%;
+    padding: 0.75rem clamp(1.25rem, 4vw, 3.5rem);
+    border-radius: 20px;
+    background: var(--surface);
+    backdrop-filter: blur(20px);
+    box-shadow: var(--shadow-sm);
+}
+
+.nav-link {
+    text-decoration: none;
+    padding: 0.55rem 1.2rem;
+    border-radius: 12px;
+    font-weight: 600;
+    color: var(--text-muted);
+    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link.active {
+    color: var(--accent);
+    background: rgba(99, 102, 241, 0.18);
+    transform: translateY(-1px);
+}
+
+.page-content {
+    width: 100%;
+    margin: 0;
+    padding: 0 clamp(1.75rem, 5vw, 4rem) 3.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+}
+
+.calendar-section,
+.stats-section {
+    background: var(--surface);
+    border: 1px solid var(--border-light);
+    border-radius: 28px;
+    padding: clamp(1.8rem, 4vw, 3.2rem);
+    box-shadow: var(--shadow-lg);
+    backdrop-filter: blur(26px);
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+}
+
+.calendar-section::before,
+.stats-section::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.08), rgba(59, 130, 246, 0.08));
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.calendar-section > *,
+.stats-section > * {
+    position: relative;
+    z-index: 1;
+}
+
+.calendar-controls {
+    display: grid;
+    gap: 1.75rem;
+    align-items: center;
+    width: 100%;
+    grid-template-columns: minmax(260px, 1.1fr) minmax(200px, 0.7fr) minmax(200px, 0.7fr) minmax(300px, 1fr);
+}
+
+.month-switcher {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+}
+
+.current-month {
+    font-size: 1.35rem;
+    font-weight: 700;
+    text-transform: capitalize;
+    color: var(--text-color);
+    letter-spacing: 0.01em;
+}
+
+.control-button,
+.primary-button,
+.secondary-button,
+.danger-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    border-radius: 14px;
+    border: 1px solid transparent;
+    padding: 0.55rem 1.1rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    font-family: inherit;
+}
+
+.control-button {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    border-color: rgba(99, 102, 241, 0.4);
+    color: var(--accent);
+    background: var(--surface-strong);
+    box-shadow: var(--shadow-sm);
+}
+
+.control-button:hover {
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
+}
+
+.primary-button {
+    background: linear-gradient(135deg, #6366f1, #4338ca);
+    color: #fff;
+    box-shadow: 0 14px 30px rgba(79, 70, 229, 0.35);
+}
+
+.primary-button:hover {
+    background: linear-gradient(135deg, var(--accent-hover), #3730a3);
+    box-shadow: 0 20px 35px rgba(79, 70, 229, 0.45);
+    transform: translateY(-1px);
+}
+
+.secondary-button {
+    background: var(--surface-strong);
+    border-color: rgba(148, 163, 184, 0.4);
+    color: var(--text-color);
+    box-shadow: var(--shadow-sm);
+}
+
+.secondary-button:hover {
+    border-color: rgba(99, 102, 241, 0.45);
+    color: var(--accent);
+    transform: translateY(-1px);
+}
+
+.danger-button {
+    background: linear-gradient(135deg, #f97316, #ea580c);
+    color: #fff;
+    border-color: rgba(234, 88, 12, 0.65);
+    box-shadow: 0 14px 28px rgba(234, 88, 12, 0.28);
+}
+
+.danger-button:hover {
+    background: linear-gradient(135deg, #f97316, #c2410c);
+    box-shadow: 0 20px 34px rgba(234, 88, 12, 0.35);
+    transform: translateY(-1px);
+}
+
+.toggle-edit label,
+.approval-toggle label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    background: var(--surface-strong);
+    border-radius: 14px;
+    padding: 0.6rem 0.9rem;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    box-shadow: var(--shadow-sm);
+}
+
+.toggle-edit,
+.approval-toggle {
+    justify-self: center;
+}
+
+.toggle-edit input,
+.approval-toggle input {
+    width: 1.2rem;
+    height: 1.2rem;
+    accent-color: var(--accent);
+}
+
+.toggle-edit label.disabled,
+.approval-toggle label.disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
+.calendar-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    width: 100%;
+}
+
+.info-message {
+    min-height: 1.5rem;
+    margin-top: 0.5rem;
+    margin-bottom: 1rem;
+    padding: 0.7rem 1rem;
+    border-radius: 12px;
+    background: rgba(99, 102, 241, 0.12);
+    color: var(--accent-hover);
+    font-weight: 500;
+    box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.2);
+}
+
+.info-message:empty {
+    display: none;
+}
+
+.calendar-container {
+    width: 100%;
+    overflow-x: auto;
+    border-radius: 18px;
+    background: var(--surface-strong);
+    border: 1px solid var(--border-light);
+    box-shadow: var(--shadow-md);
+    padding: 0.35rem;
+}
+
+.calendar-table {
+    border-collapse: separate;
+    border-spacing: 0;
+    width: 100%;
+    min-width: 760px;
+    background: var(--surface-strong);
+    border-radius: 14px;
+    overflow: hidden;
+}
+
+.calendar-table thead th {
+    position: sticky;
+    top: 0;
+    background: linear-gradient(180deg, rgba(99, 102, 241, 0.18), rgba(99, 102, 241, 0.05));
+    color: var(--text-color);
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    padding: 0.85rem 0.65rem;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+    backdrop-filter: blur(12px);
+    z-index: 7;
+}
+
+.calendar-table th.weekend {
+    background: linear-gradient(180deg, rgba(16, 185, 129, 0.35), rgba(16, 185, 129, 0.15));
+}
+
+.calendar-table th:first-child,
+.calendar-table td:first-child {
+    position: sticky;
+    left: 0;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(244, 244, 255, 0.85));
+    color: var(--text-color);
+    font-weight: 600;
+    border-right: 1px solid rgba(148, 163, 184, 0.25);
+    z-index: 8;
+}
+
+.calendar-table th,
+.calendar-table td {
+    text-align: center;
+    padding: 0.85rem 0.65rem;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    border-right: 1px solid rgba(148, 163, 184, 0.15);
+    min-width: 2.6rem;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.calendar-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.calendar-table tbody tr {
+    position: relative;
+}
+
+.calendar-table tbody tr::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: var(--surface-strong);
+    z-index: -1;
+    pointer-events: none;
+    transition: background 0.2s ease;
+}
+
+.calendar-table tbody tr:hover {
+    z-index: 4;
+}
+
+.calendar-table tbody tr:hover::before {
+    background: #f8faff;
+}
+
+.calendar-table tbody tr:hover td:not(:first-child):not(.weekend):not(.range-vacation):not(.range-trip):not(.range-sick):not(.range-study) {
+    background: #f8faff;
+}
+
+.calendar-table tbody tr:hover td:first-child {
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(244, 244, 255, 0.92));
+}
+
+.calendar-table tbody tr:hover td.weekend:not(.range-vacation):not(.range-trip):not(.range-sick):not(.range-study) {
+    background: rgba(16, 185, 129, 0.32);
+}
+
+.calendar-table td.weekend {
+    background: var(--weekend-bg);
+    color: var(--text-color);
+}
+
+.calendar-table td.editable {
+    cursor: pointer;
+}
+
+.calendar-table td.has-event {
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.calendar-table td.event-duty {
+    color: var(--important-color);
+    font-size: 1.1rem;
+}
+
+.calendar-table td.event-important {
+    color: #0f172a;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+}
+
+.calendar-table td.range-vacation,
+.calendar-table td.range-trip,
+.calendar-table td.range-sick,
+.calendar-table td.range-study {
+    color: var(--text-color);
+}
+
+.calendar-table td.range-vacation {
+    background: var(--range-vacation);
+}
+
+.calendar-table td.range-trip {
+    background: var(--range-trip);
+}
+
+.calendar-table td.range-sick {
+    background: var(--range-sick);
+}
+
+.calendar-table td.range-study {
+    background: var(--range-study);
+}
+
+.calendar-table td.range-start {
+    border-top-left-radius: 12px;
+    border-bottom-left-radius: 12px;
+}
+
+.calendar-table td.range-end {
+    border-top-right-radius: 12px;
+    border-bottom-right-radius: 12px;
+}
+
+.pending-selection {
+    outline: 2px dashed var(--accent);
+    outline-offset: -4px;
+}
+
+.participant-actions {
+    display: flex;
+    justify-content: center;
+    gap: 0.4rem;
+    margin-top: 0.5rem;
+}
+
+.participant-actions button {
+    border: none;
+    border-radius: 8px;
+    padding: 0.25rem 0.4rem;
+    font-size: 0.75rem;
+    cursor: pointer;
+    background: var(--accent-lighter);
+    color: var(--accent);
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.participant-actions button:hover:not(:disabled) {
+    background: var(--accent-light);
+    transform: translateY(-1px);
+}
+
+.participant-actions button:disabled {
+    opacity: 0.35;
+    cursor: default;
+}
+
+.event-menu {
+    position: absolute;
+    background: var(--surface-strong);
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    box-shadow: var(--shadow-lg);
+    display: flex;
+    flex-direction: column;
+    min-width: 190px;
+    overflow: hidden;
+    z-index: 15;
+    backdrop-filter: blur(18px);
+}
+
+.event-menu button {
+    background: transparent;
+    border: none;
+    padding: 0.75rem 1rem;
+    text-align: left;
+    font-weight: 500;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, padding-left 0.2s ease;
+}
+
+.event-menu button:hover {
+    background: rgba(99, 102, 241, 0.12);
+    color: var(--accent);
+    padding-left: 1.2rem;
+}
+
+.hidden {
+    display: none !important;
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 30;
+    padding: 1rem;
+}
+
+.modal .modal-content {
+    background: var(--surface-strong);
+    border-radius: 18px;
+    padding: 1.75rem;
+    width: min(380px, 90%);
+    box-shadow: var(--shadow-md);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.modal-message {
+    margin-bottom: 1.25rem;
+    font-size: 1.05rem;
+    color: var(--text-color);
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+}
+
+.stats-section {
+    gap: 1.5rem;
+}
+
+.stats-controls {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.stats-controls label {
+    font-weight: 600;
+    color: var(--text-muted);
+}
+
+.stats-select {
+    padding: 0.55rem 0.9rem;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: var(--surface-strong);
+    font-weight: 600;
+    color: var(--text-color);
+    box-shadow: var(--shadow-sm);
+    transition: border 0.2s ease;
+}
+
+.stats-select:focus {
+    outline: none;
+    border-color: rgba(99, 102, 241, 0.45);
+}
+
+.stats-table-wrapper {
+    border-radius: 18px;
+    background: var(--surface-strong);
+    border: 1px solid var(--border-light);
+    box-shadow: var(--shadow-md);
+    overflow: hidden;
+}
+
+.stats-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.stats-table th {
+    background: linear-gradient(180deg, rgba(99, 102, 241, 0.2), rgba(99, 102, 241, 0.06));
+    color: var(--text-color);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.8rem;
+    padding: 0.85rem;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.stats-table td {
+    padding: 0.9rem;
+    text-align: center;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.stats-table td:first-child {
+    text-align: left;
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+.stats-table tbody tr:nth-child(even) {
+    background: rgba(99, 102, 241, 0.05);
+}
+
+.stats-table tbody tr:hover {
+    background: rgba(99, 102, 241, 0.12);
+    color: var(--text-color);
+}
+
+@media (max-width: 1024px) {
+    .calendar-controls {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .calendar-actions {
+        justify-content: flex-start;
+    }
+
+    .stats-controls {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
+@media (max-width: 768px) {
+    .page-content {
+        padding: 0.5rem 1rem 2rem;
+    }
+
+    .calendar-section,
+    .stats-section {
+        padding: 1.5rem;
+    }
+
+    .calendar-table {
+        min-width: 640px;
+    }
+
+    .top-nav {
+        flex-wrap: wrap;
+    }
+}
+
+@media (max-width: 480px) {
+    .month-switcher {
+        justify-content: space-between;
+    }
+
+    .calendar-actions {
+        width: 100%;
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .primary-button,
+    .secondary-button,
+    .danger-button {
+        width: 100%;
+    }
+}

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/db.php
+++ b/db.php
@@ -1,0 +1,195 @@
+<?php
+
+require_once __DIR__ . '/logger.php';
+
+function get_db(): PDO
+{
+    static $pdo = null;
+
+    if ($pdo instanceof PDO) {
+        return $pdo;
+    }
+
+    [$dbPath, $needInit] = resolveDatabasePath();
+
+    log_info('Инициализация подключения к базе данных', [
+        'path' => $dbPath,
+        'new_database' => $needInit,
+    ]);
+
+    try {
+        $pdo = new PDO('sqlite:' . $dbPath);
+    } catch (PDOException $e) {
+        log_error('Не удалось подключиться к базе данных', [
+            'path' => $dbPath,
+            'error' => $e->getMessage(),
+        ]);
+        throw $e;
+    }
+
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+    $pdo->exec('PRAGMA foreign_keys = ON');
+
+    initializeDatabase($pdo, $needInit);
+
+    return $pdo;
+}
+
+function resolveDatabasePath(): array
+{
+    $customPath = trim((string) (getenv('APP_DB_PATH') ?: ''));
+
+    if ($customPath !== '') {
+        if (!preg_match('/^(?:[a-zA-Z]:\\\\|\\\\\\\\|\/)/', $customPath)) {
+            $customPath = __DIR__ . DIRECTORY_SEPARATOR . $customPath;
+        }
+
+        $directory = dirname($customPath);
+        if (!ensureDirectoryWritable($directory)) {
+            log_error('Каталог для базы данных (APP_DB_PATH) недоступен для записи', [
+                'directory' => $directory,
+            ]);
+            throw new RuntimeException('Каталог для базы данных (APP_DB_PATH) недоступен для записи: ' . $directory);
+        }
+
+        log_info('Используется пользовательский путь для базы данных', [
+            'path' => $customPath,
+        ]);
+        return [$customPath, !file_exists($customPath)];
+    }
+
+    $directories = [
+        __DIR__ . DIRECTORY_SEPARATOR . 'data',
+        __DIR__ . DIRECTORY_SEPARATOR . 'App_Data',
+        rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'work-calendar',
+    ];
+
+    foreach ($directories as $dir) {
+        $path = $dir . DIRECTORY_SEPARATOR . 'app.db';
+        if (file_exists($path) && ensureDirectoryWritable($dir)) {
+            log_info('Обнаружена существующая база данных', [
+                'path' => $path,
+            ]);
+            return [$path, false];
+        }
+    }
+
+    foreach ($directories as $dir) {
+        if (!ensureDirectoryWritable($dir)) {
+            log_warning('Каталог недоступен для записи при подготовке базы данных', [
+                'directory' => $dir,
+            ]);
+            continue;
+        }
+
+        $path = $dir . DIRECTORY_SEPARATOR . 'app.db';
+        log_info('Подготовлен путь для новой базы данных', [
+            'path' => $path,
+        ]);
+        return [$path, !file_exists($path)];
+    }
+
+    log_error('Не удалось подготовить каталог для базы данных', []);
+    throw new RuntimeException('Не удалось подготовить каталог для базы данных. Проверьте права на запись или задайте переменную окружения APP_DB_PATH.');
+}
+
+function ensureDirectoryWritable(string $dir): bool
+{
+    $dir = rtrim($dir, "\\/");
+
+    if ($dir === '') {
+        return false;
+    }
+
+    if (!is_dir($dir)) {
+        if (!@mkdir($dir, 0777, true) && !is_dir($dir)) {
+            log_warning('Не удалось создать каталог для базы данных', [
+                'directory' => $dir,
+            ]);
+            return false;
+        }
+    }
+
+    if (!is_writable($dir)) {
+        @chmod($dir, 0777);
+    }
+
+    if (!is_writable($dir)) {
+        $testFile = $dir . DIRECTORY_SEPARATOR . '.permissions_test';
+        if (@file_put_contents($testFile, 'ok') === false) {
+            log_warning('Каталог недоступен для записи', [
+                'directory' => $dir,
+            ]);
+            return false;
+        }
+        @unlink($testFile);
+    }
+
+    return true;
+}
+
+function initializeDatabase(PDO $pdo, bool $isNew): void
+{
+    log_info('Проверка структуры базы данных', [
+        'is_new' => $isNew,
+    ]);
+    $pdo->exec(
+        'CREATE TABLE IF NOT EXISTS participants (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            sort_order INTEGER NOT NULL DEFAULT 0
+        )'
+    );
+
+    $pdo->exec(
+        'CREATE TABLE IF NOT EXISTS events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            participant_id INTEGER NOT NULL,
+            type TEXT NOT NULL,
+            start_date TEXT NOT NULL,
+            end_date TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY(participant_id) REFERENCES participants(id) ON DELETE CASCADE
+        )'
+    );
+
+    $pdo->exec(
+        'CREATE TABLE IF NOT EXISTS approvals (
+            year INTEGER NOT NULL,
+            month INTEGER NOT NULL,
+            approved INTEGER NOT NULL DEFAULT 0,
+            approved_at TEXT,
+            PRIMARY KEY (year, month)
+        )'
+    );
+
+    if ($isNew) {
+        log_info('Создаётся новая база данных, выполняется заполнение данными по умолчанию');
+        seedParticipants($pdo);
+    } else {
+        $count = (int) $pdo->query('SELECT COUNT(*) FROM participants')->fetchColumn();
+        if ($count === 0) {
+            log_info('База данных пуста, выполняется заполнение данными по умолчанию');
+            seedParticipants($pdo);
+        }
+    }
+}
+
+function seedParticipants(PDO $pdo): void
+{
+    $defaults = ['Иванов', 'Петров', 'Сидоров'];
+    log_info('Первичное заполнение участников', [
+        'participants' => $defaults,
+    ]);
+    $stmt = $pdo->prepare('INSERT INTO participants (name, sort_order) VALUES (:name, :sort)');
+    foreach ($defaults as $index => $name) {
+        $stmt->execute([
+            ':name' => $name,
+            ':sort' => $index,
+        ]);
+    }
+    log_info('Первичное заполнение участников завершено', [
+        'count' => count($defaults),
+    ]);
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,106 @@
+<?php
+require __DIR__ . '/db.php';
+
+$page = $_GET['page'] ?? 'home';
+$page = $page === 'stats' ? 'stats' : 'home';
+
+?><!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>График дежурств</title>
+    <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body data-page="<?php echo htmlspecialchars($page, ENT_QUOTES); ?>">
+    <header class="site-header">
+        <nav class="top-nav">
+            <a href="index.php" class="nav-link <?php echo $page === 'home' ? 'active' : ''; ?>">Главная</a>
+            <a href="index.php?page=stats" class="nav-link <?php echo $page === 'stats' ? 'active' : ''; ?>">Статистика</a>
+        </nav>
+    </header>
+
+    <main class="page-content">
+        <?php if ($page === 'home'): ?>
+            <section class="calendar-section">
+                <div class="calendar-controls">
+                    <div class="month-switcher">
+                        <button type="button" id="prev-month" class="control-button">◀</button>
+                        <div id="current-month" class="current-month"></div>
+                        <button type="button" id="next-month" class="control-button">▶</button>
+                    </div>
+                    <div class="toggle-edit">
+                        <label>
+                            <input type="checkbox" id="edit-toggle">
+                            Режим редактирования
+                        </label>
+                    </div>
+                    <div class="approval-toggle">
+                        <label>
+                            <input type="checkbox" id="approval-toggle">
+                            Утверждено
+                        </label>
+                    </div>
+                    <div class="calendar-actions">
+                        <button type="button" id="distribute" class="primary-button">Распределить</button>
+                        <button type="button" id="clear-duty" class="danger-button">Очистить</button>
+                        <button type="button" id="generate-report" class="secondary-button">Отчет</button>
+                        <button type="button" id="add-participant" class="secondary-button">Добавить участника</button>
+                    </div>
+                </div>
+                <div id="info-message" class="info-message" role="status"></div>
+                <div id="calendar-container" class="calendar-container"></div>
+            </section>
+        <?php else: ?>
+            <section class="stats-section">
+                <div class="stats-controls">
+                    <label for="stats-year">Год:</label>
+                    <select id="stats-year" class="stats-select"></select>
+                </div>
+                <div class="stats-table-wrapper">
+                    <table class="stats-table">
+                        <thead>
+                            <tr>
+                                <th>ФИО</th>
+                                <th>Пн</th>
+                                <th>Вт</th>
+                                <th>Ср</th>
+                                <th>Чт</th>
+                                <th>Пт</th>
+                                <th>Сб</th>
+                                <th>Вс</th>
+                                <th>Отпуск</th>
+                                <th>Больничный</th>
+                                <th>Командировка</th>
+                                <th>Учеба</th>
+                                <th>Всего</th>
+                            </tr>
+                        </thead>
+                        <tbody id="stats-body"></tbody>
+                    </table>
+                </div>
+            </section>
+        <?php endif; ?>
+    </main>
+
+    <div id="event-menu" class="event-menu hidden">
+        <button type="button" data-type="duty">Дежурство</button>
+        <button type="button" data-type="important">Важный день</button>
+        <button type="button" data-type="vacation">Отпуск</button>
+        <button type="button" data-type="trip">Командировка</button>
+        <button type="button" data-type="sick">Больничный</button>
+        <button type="button" data-type="study">Учеба</button>
+    </div>
+
+    <div id="confirm-modal" class="modal hidden" role="dialog" aria-modal="true">
+        <div class="modal-content">
+            <div class="modal-message" id="modal-message"></div>
+            <div class="modal-actions">
+                <button type="button" id="modal-confirm" class="primary-button">Да</button>
+                <button type="button" id="modal-cancel" class="secondary-button">Нет</button>
+            </div>
+        </div>
+    </div>
+
+    <script src="assets/app.js"></script>
+</body>
+</html>

--- a/logger.php
+++ b/logger.php
@@ -1,0 +1,114 @@
+<?php
+
+const LOG_LEVEL_INFO = 'INFO';
+const LOG_LEVEL_WARNING = 'WARNING';
+const LOG_LEVEL_ERROR = 'ERROR';
+
+function log_info(string $message, array $context = []): void
+{
+    log_message(LOG_LEVEL_INFO, $message, $context);
+}
+
+function log_warning(string $message, array $context = []): void
+{
+    log_message(LOG_LEVEL_WARNING, $message, $context);
+}
+
+function log_error(string $message, array $context = []): void
+{
+    log_message(LOG_LEVEL_ERROR, $message, $context);
+}
+
+function log_message(string $level, string $message, array $context = []): void
+{
+    $timestamp = (new DateTimeImmutable('now'))->format('Y-m-d H:i:s');
+    $line = sprintf('[%s] %s: %s', $timestamp, strtoupper($level), $message);
+
+    if (!empty($context)) {
+        $encoded = json_encode($context, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if ($encoded !== false) {
+            $line .= ' ' . $encoded;
+        }
+    }
+
+    $path = resolve_log_path();
+
+    if ($path === null) {
+        error_log($line);
+        return;
+    }
+
+    $result = @file_put_contents($path, $line . PHP_EOL, FILE_APPEND | LOCK_EX);
+    if ($result === false) {
+        error_log($line);
+    }
+}
+
+function resolve_log_path(): ?string
+{
+    static $cached = false;
+    static $path = null;
+
+    if ($cached) {
+        return $path;
+    }
+
+    $cached = true;
+
+    $customPath = trim((string) (getenv('APP_LOG_PATH') ?: ''));
+    if ($customPath !== '') {
+        if (!preg_match('/^(?:[a-zA-Z]:\\\\|\\\\\\\\|\/)/', $customPath)) {
+            $customPath = __DIR__ . DIRECTORY_SEPARATOR . $customPath;
+        }
+        $dir = dirname($customPath);
+        if (ensure_log_directory($dir)) {
+            $path = $customPath;
+            return $path;
+        }
+    }
+
+    $directories = [
+        __DIR__ . DIRECTORY_SEPARATOR . 'data',
+        __DIR__ . DIRECTORY_SEPARATOR . 'App_Data',
+        rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'work-calendar',
+    ];
+
+    foreach ($directories as $dir) {
+        if (!ensure_log_directory($dir)) {
+            continue;
+        }
+        $path = rtrim($dir, '\\/') . DIRECTORY_SEPARATOR . 'app.log';
+        return $path;
+    }
+
+    $path = null;
+    return null;
+}
+
+function ensure_log_directory(string $dir): bool
+{
+    $dir = rtrim($dir, '\\/');
+    if ($dir === '') {
+        return false;
+    }
+
+    if (!is_dir($dir)) {
+        if (!@mkdir($dir, 0777, true) && !is_dir($dir)) {
+            return false;
+        }
+    }
+
+    if (!is_writable($dir)) {
+        @chmod($dir, 0777);
+    }
+
+    if (!is_writable($dir)) {
+        $testFile = $dir . DIRECTORY_SEPARATOR . '.log_permissions_test';
+        if (@file_put_contents($testFile, 'ok') === false) {
+            return false;
+        }
+        @unlink($testFile);
+    }
+
+    return true;
+}


### PR DESCRIPTION
## Summary
- smooth out calendar hover rendering by layering row backgrounds and expanding range color tokens, including a new hue for study events
- add the "Учеба" range event alongside command trips in the UI, statistics, and persistence rules so it behaves like other multi-day states
- teach the DOCX export to merge and shade every range event type (vacations, trips, sick leave, study) while keeping weekend highlighting intact

## Testing
- php -l api.php
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68d0fa3e4acc83229971fb43bac228ce